### PR TITLE
Version 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-bidi"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"


### PR DESCRIPTION
The code features unicode version 8.0.0, but version 0.2.2 is still on unicode 7.0.0
I ended up having to look at the code to realise what's wrong :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/unicode-bidi/23)
<!-- Reviewable:end -->
