### PR TITLE
Fix warning: unused import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ fn assign_levels_to_removed_chars(para_level: u8, classes: &[BidiClass], levels:
 ///
 /// http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions
 mod explicit {
-    use super::{BidiClass, is_rtl};
+    use super::{BidiClass};
     use super::BidiClass::*;
 
     /// Compute explicit embedding levels for one paragraph of text (X1-X8).


### PR DESCRIPTION
Fix compile warning:
```
warning: unused import: `is_rtl`
   --> src/lib.rs:353:28
    |
353 |     use super::{BidiClass, is_rtl};
    |                            ^^^^^^
    |
    = note: #[warn(unused_imports)] on by default
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/unicode-bidi/26)
<!-- Reviewable:end -->
