### PR TITLE
Improve basic conformance and add more unit tests

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -18,15 +18,10 @@ use test::Bencher;
 use unicode_bidi::BidiInfo;
 
 
-const LTR_TEXTS: &[&str] = &[
-    "abc\ndef\nghi",
-    "abc 123\ndef 456\nghi 789",
-];
+const LTR_TEXTS: &[&str] = &["abc\ndef\nghi", "abc 123\ndef 456\nghi 789"];
 
-const BIDI_TEXTS: &[&str] = &[
-    "ابجد\nهوز\nحتی",
-    "ابجد ۱۲۳\nهوز ۴۵۶\nحتی ۷۸۹",
-];
+const BIDI_TEXTS: &[&str] =
+    &["ابجد\nهوز\nحتی", "ابجد ۱۲۳\nهوز ۴۵۶\nحتی ۷۸۹"];
 
 
 fn bench_bidi_info_new(b: &mut Bencher, texts: &[&str]) {

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -23,11 +23,11 @@ use BidiClass::*;
 pub fn compute(
     text: &str,
     para_level: Level,
-    initial_classes: &[BidiClass],
+    original_classes: &[BidiClass],
     levels: &mut [Level],
     processing_classes: &mut [BidiClass],
 ) {
-    assert!(text.len() == initial_classes.len());
+    assert!(text.len() == original_classes.len());
 
     // http://www.unicode.org/reports/tr9/#X1
     let mut stack = DirectionalStatusStack::new();
@@ -38,14 +38,14 @@ pub fn compute(
     let mut valid_isolate_count = 0u32;
 
     for (i, c) in text.char_indices() {
-        match initial_classes[i] {
+        match original_classes[i] {
 
             // Rules X2-X5c
             RLE | LRE | RLO | LRO | RLI | LRI | FSI => {
                 let last_level = stack.last().level;
 
                 // X5a-X5c: Isolate initiators get the level of the last entry on the stack.
-                let is_isolate = matches!(initial_classes[i], RLI | LRI | FSI);
+                let is_isolate = matches!(original_classes[i], RLI | LRI | FSI);
                 if is_isolate {
                     levels[i] = last_level;
                     match stack.last().status {
@@ -55,7 +55,7 @@ pub fn compute(
                     }
                 }
 
-                let new_level = if is_rtl(initial_classes[i]) {
+                let new_level = if is_rtl(original_classes[i]) {
                     last_level.new_explicit_next_rtl()
                 } else {
                     last_level.new_explicit_next_ltr()
@@ -64,7 +64,7 @@ pub fn compute(
                    overflow_embedding_count == 0 {
                     let new_level = new_level.unwrap();
                     stack.push(
-                        new_level, match initial_classes[i] {
+                        new_level, match original_classes[i] {
                             RLO => OverrideStatus::RTL,
                             LRO => OverrideStatus::LTR,
                             RLI | LRI | FSI => OverrideStatus::Isolate,

--- a/src/format_chars.rs
+++ b/src/format_chars.rs
@@ -34,9 +34,9 @@ pub const PDI: char = '\u{2069}';
 pub const LRE: char = '\u{202A}';
 /// RIGHT-TO-LEFT EMBEDDING
 pub const RLE: char = '\u{202B}';
+/// POP DIRECTIONAL FORMATTING
+pub const PDF: char = '\u{202C}';
 /// LEFT-TO-RIGHT OVERRIDE
 pub const LRO: char = '\u{202D}';
 /// RIGHT-TO-LEFT OVERRIDE
 pub const RLO: char = '\u{202E}';
-/// POP DIRECTIONAL FORMATTING
-pub const PDF: char = '\u{202C}';

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -26,6 +26,9 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
     // by an "earlier" rule.  We should either split this into separate passes, or preserve
     // extra state so each rule can see the correct previous class.
 
+    // FIXME: Also, this could be the cause of increased failure for using longer-UTF-8 chars in
+    // conformance tests, like BidiTest:69635 (AL ET EN)
+
     let mut prev_class = sequence.sos;
     let mut last_strong_is_al = false;
     let mut et_run_indices = Vec::new(); // for W5

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,9 @@ impl<'text> BidiInfo<'text> {
     /// Re-order a line based on resolved levels and return the line in display order.
     pub fn reorder_line(&self, para: &ParagraphInfo, line: Range<usize>) -> Cow<'text, str> {
         let (levels, runs) = self.visual_runs(para, line.clone());
-        if runs.len() == 1 && levels[runs[0].start].is_ltr() {
+
+        // If all isolating run sequences are LTR, no reordering is needed
+        if runs.iter().all(|run| levels[run.start].is_ltr()) {
             return self.text[line.clone()].into();
         }
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -24,12 +24,15 @@ use BidiClass::*;
 /// Represented as a range of byte indices.
 pub type LevelRun = Range<usize>;
 
+
 /// Output of `isolating_run_sequences` (steps X9-X10)
+#[derive(Debug, PartialEq)]
 pub struct IsolatingRunSequence {
     pub runs: Vec<LevelRun>,
     pub sos: BidiClass, // Start-of-sequence type.
     pub eos: BidiClass, // End-of-sequence type.
 }
+
 
 /// Compute the set of isolating run sequences.
 ///
@@ -47,7 +50,6 @@ pub fn isolating_run_sequences(
 
     // Compute the set of isolating run sequences.
     // http://www.unicode.org/reports/tr9/#BD13
-
     let mut sequences = Vec::with_capacity(runs.len());
 
     // When we encounter an isolate initiator, we push the current sequence onto the
@@ -84,43 +86,53 @@ pub fn isolating_run_sequences(
 
     // Determine the `sos` and `eos` class for each sequence.
     // http://www.unicode.org/reports/tr9/#X10
-    return sequences
-               .into_iter()
-               .map(
-        |sequence| {
-            assert!(!sequence.len() > 0);
-            let start = sequence[0].start;
-            let end = sequence[sequence.len() - 1].end;
+    sequences
+        .into_iter()
+        .map(
+            |sequence: Vec<LevelRun>| {
+                assert!(!sequence.is_empty());
 
-            // Get the level inside these level runs.
-            let level = levels[start];
+                let start_of_seq = sequence[0].start;
+                let end_of_seq = sequence[sequence.len() - 1].end;
+                let seq_level = levels[start_of_seq];
 
-            // Get the level of the last non-removed char before the runs.
-            let pred_level = match original_classes[..start]
-                      .iter()
-                      .rposition(not_removed_by_x9) {
-                Some(idx) => levels[idx],
-                None => para_level,
-            };
+                #[cfg(test)]
+                for run in sequence.clone() {
+                    for idx in run {
+                        if not_removed_by_x9(&original_classes[idx]) {
+                            assert_eq!(seq_level, levels[idx]);
+                        }
+                    }
+                }
 
-            // Get the level of the next non-removed char after the runs.
-            let succ_level = if matches!(original_classes[end - 1], RLI | LRI | FSI) {
-                para_level
-            } else {
-                match original_classes[end..].iter().position(not_removed_by_x9) {
+                // Get the level of the last non-removed char before the runs.
+                let pred_level = match original_classes[..start_of_seq]
+                          .iter()
+                          .rposition(not_removed_by_x9) {
                     Some(idx) => levels[idx],
                     None => para_level,
-                }
-            };
+                };
 
-            IsolatingRunSequence {
-                runs: sequence,
-                sos: max(level, pred_level).bidi_class(),
-                eos: max(level, succ_level).bidi_class(),
+                // Get the level of the next non-removed char after the runs.
+                let succ_level = if matches!(original_classes[end_of_seq - 1], RLI | LRI | FSI) {
+                    para_level
+                } else {
+                    match original_classes[end_of_seq..]
+                              .iter()
+                              .position(not_removed_by_x9) {
+                        Some(idx) => levels[end_of_seq + idx],
+                        None => para_level,
+                    }
+                };
+
+                IsolatingRunSequence {
+                    runs: sequence,
+                    sos: max(seq_level, pred_level).bidi_class(),
+                    eos: max(seq_level, succ_level).bidi_class(),
+                }
             }
-        }
-    )
-               .collect();
+        )
+        .collect()
 }
 
 /// Finds the level runs in a paragraph.
@@ -136,7 +148,6 @@ fn level_runs(levels: &[Level], original_classes: &[BidiClass]) -> Vec<LevelRun>
 
     let mut current_run_level = levels[0];
     let mut current_run_start = 0;
-
     for i in 1..levels.len() {
         if !removed_by_x9(original_classes[i]) {
             if levels[i] != current_run_level {
@@ -148,6 +159,7 @@ fn level_runs(levels: &[Level], original_classes: &[BidiClass]) -> Vec<LevelRun>
         }
     }
     runs.push(current_run_start..levels.len());
+
     runs
 }
 
@@ -169,27 +181,169 @@ mod tests {
 
     #[test]
     fn test_level_runs() {
-        let levels = &[0, 0, 0, 1, 1, 2, 0, 0];
+        assert_eq!(level_runs(&Level::vec(&[]), &[]), &[]);
         assert_eq!(
-            level_runs(&Level::vec(levels), &[L; 8]),
+            level_runs(&Level::vec(&[0, 0, 0, 1, 1, 2, 0, 0]), &[L; 8]),
             &[0..3, 3..5, 5..6, 6..8]
         );
     }
 
-    /// Example 3 from http://www.unicode.org/reports/tr9/#BD13:
+    // From http://www.unicode.org/reports/tr9/#BD13
     #[cfg_attr(rustfmt, rustfmt_skip)]
     #[test]
     fn test_isolating_run_sequences() {
-        //  char index  0  1    2   3    4  5  6  7    8   9   10
-        let classes = &[L, RLI, AL, LRI, L, R, L, PDI, AL, PDI, L];
-        let levels =  &[0, 0,   1,  1,   2, 3, 2, 1,   1,  0,   0];
-        let para_level = Level::ltr();
 
-        let sequences = isolating_run_sequences(para_level, classes, &Level::vec(levels));
-        let runs: Vec<Vec<LevelRun>> = sequences.iter().map(|s| s.runs.clone()).collect();
+        // == Example 1 ==
+        // text1·RLE·text2·PDF·RLE·text3·PDF·text4
+        // index        0    1  2    3    4  5    6  7
+        let classes = &[L, RLE, L, PDF, RLE, L, PDF, L];
+        let levels =  &[0,   1, 1,   1,   1, 1,   1, 0];
+        let para_level = Level::ltr();
+        let mut sequences = isolating_run_sequences(para_level, classes, &Level::vec(levels));
+        sequences.sort_by(|a, b| a.runs[0].clone().cmp(b.runs[0].clone()));
         assert_eq!(
-            runs,
-            vec![vec![4..5], vec![5..6], vec![6..7], vec![2..4, 7..9], vec![0..2, 9..11]]
+            sequences.iter().map(|s| s.runs.clone()).collect::<Vec<_>>(),
+            vec![vec![0..2], vec![2..7], vec![7..8]]
+        );
+
+        // == Example 2 ==
+        // text1·RLI·text2·PDI·RLI·text3·PDI·text4
+        // index        0    1  2    3    4  5    6  7
+        let classes = &[L, RLI, L, PDI, RLI, L, PDI, L];
+        let levels =  &[0,   0, 1,   0,   0, 1,   0, 0];
+        let para_level = Level::ltr();
+        let mut sequences = isolating_run_sequences(para_level, classes, &Level::vec(levels));
+        sequences.sort_by(|a, b| a.runs[0].clone().cmp(b.runs[0].clone()));
+        assert_eq!(
+            sequences.iter().map(|s| s.runs.clone()).collect::<Vec<_>>(),
+            vec![vec![0..2, 3..5, 6..8], vec![2..3], vec![5..6]]
+        );
+
+        // == Example 3 ==
+        // text1·RLI·text2·LRI·text3·RLE·text4·PDF·text5·PDI·text6·PDI·text7
+        // index        0    1  2    3  4    5  6    7  8    9  10  11  12
+        let classes = &[L, RLI, L, LRI, L, RLE, L, PDF, L, PDI, L, PDI,  L];
+        let levels =  &[0,   0, 1,   1, 2,   3, 3,   3, 2,   1, 1,   0,  0];
+        let para_level = Level::ltr();
+        let mut sequences = isolating_run_sequences(para_level, classes, &Level::vec(levels));
+        sequences.sort_by(|a, b| a.runs[0].clone().cmp(b.runs[0].clone()));
+        assert_eq!(
+            sequences.iter().map(|s| s.runs.clone()).collect::<Vec<_>>(),
+            vec![vec![0..2, 11..13], vec![2..4, 9..11], vec![4..6], vec![6..8], vec![8..9]]
+        );
+    }
+
+    // From http://www.unicode.org/reports/tr9/#X10
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[test]
+    fn test_isolating_run_sequences_sos_and_eos() {
+
+        // == Example 1 ==
+        // text1·RLE·text2·LRE·text3·PDF·text4·PDF·RLE·text5·PDF·text6
+        // index        0    1  2    3  4    5  6    7    8  9   10  11
+        let classes = &[L, RLE, L, LRE, L, PDF, L, PDF, RLE, L, PDF,  L];
+        let levels =  &[0,   1, 1,   2, 2,   2, 1,   1,   1, 1,   1,  0];
+        let para_level = Level::ltr();
+        let mut sequences = isolating_run_sequences(para_level, classes, &Level::vec(levels));
+        sequences.sort_by(|a, b| a.runs[0].clone().cmp(b.runs[0].clone()));
+
+        // text1
+        assert_eq!(
+            &sequences[0],
+            &IsolatingRunSequence {
+                runs: vec![0..2],
+                sos: L,
+                eos: R,
+            }
+        );
+
+        // text2
+        assert_eq!(
+            &sequences[1],
+            &IsolatingRunSequence {
+                runs: vec![2..4],
+                sos: R,
+                eos: L,
+            }
+        );
+
+        // text3
+        assert_eq!(
+            &sequences[2],
+            &IsolatingRunSequence {
+                runs: vec![4..6],
+                sos: L,
+                eos: L,
+            }
+        );
+
+        // text4 text5
+        assert_eq!(
+            &sequences[3],
+            &IsolatingRunSequence {
+                runs: vec![6..11],
+                sos: L,
+                eos: R,
+            }
+        );
+
+        // text6
+        assert_eq!(
+            &sequences[4],
+            &IsolatingRunSequence {
+                runs: vec![11..12],
+                sos: R,
+                eos: L,
+            }
+        );
+
+        // == Example 2 ==
+        // text1·RLI·text2·LRI·text3·PDI·text4·PDI·RLI·text5·PDI·text6
+        // index        0    1  2    3  4    5  6    7    8  9   10  11
+        let classes = &[L, RLI, L, LRI, L, PDI, L, PDI, RLI, L, PDI,  L];
+        let levels =  &[0,   0, 1,   1, 2,   1, 1,   0,   0, 1,   0,  0];
+        let para_level = Level::ltr();
+        let mut sequences = isolating_run_sequences(para_level, classes, &Level::vec(levels));
+        sequences.sort_by(|a, b| a.runs[0].clone().cmp(b.runs[0].clone()));
+
+        // text1·RLI·PDI·RLI·PDI·text6
+        assert_eq!(
+            &sequences[0],
+            &IsolatingRunSequence {
+                runs: vec![0..2, 7..9, 10..12],
+                sos: L,
+                eos: L,
+            }
+        );
+
+        // text2·LRI·PDI·text4
+        assert_eq!(
+            &sequences[1],
+            &IsolatingRunSequence {
+                runs: vec![2..4, 5..7],
+                sos: R,
+                eos: R,
+            }
+        );
+
+        // text3
+        assert_eq!(
+            &sequences[2],
+            &IsolatingRunSequence {
+                runs: vec![4..5],
+                sos: L,
+                eos: L,
+            }
+        );
+
+        // text5
+        assert_eq!(
+            &sequences[3],
+            &IsolatingRunSequence {
+                runs: vec![9..10],
+                sos: R,
+                eos: R,
+            }
         );
     }
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -40,10 +40,10 @@ pub struct IsolatingRunSequence {
 /// Note: This function does *not* return the sequences in order by their first characters.
 pub fn isolating_run_sequences(
     para_level: Level,
-    initial_classes: &[BidiClass],
+    original_classes: &[BidiClass],
     levels: &[Level],
 ) -> Vec<IsolatingRunSequence> {
-    let runs = level_runs(levels, initial_classes);
+    let runs = level_runs(levels, original_classes);
 
     // Compute the set of isolating run sequences.
     // http://www.unicode.org/reports/tr9/#BD13
@@ -58,8 +58,8 @@ pub fn isolating_run_sequences(
         assert!(run.len() > 0);
         assert!(stack.len() > 0);
 
-        let start_class = initial_classes[run.start];
-        let end_class = initial_classes[run.end - 1];
+        let start_class = original_classes[run.start];
+        let end_class = original_classes[run.end - 1];
 
         let mut sequence = if start_class == PDI && stack.len() > 1 {
             // Continue a previous sequence interrupted by an isolate.
@@ -96,16 +96,18 @@ pub fn isolating_run_sequences(
             let level = levels[start];
 
             // Get the level of the last non-removed char before the runs.
-            let pred_level = match initial_classes[..start].iter().rposition(not_removed_by_x9) {
+            let pred_level = match original_classes[..start]
+                      .iter()
+                      .rposition(not_removed_by_x9) {
                 Some(idx) => levels[idx],
                 None => para_level,
             };
 
             // Get the level of the next non-removed char after the runs.
-            let succ_level = if matches!(initial_classes[end - 1], RLI | LRI | FSI) {
+            let succ_level = if matches!(original_classes[end - 1], RLI | LRI | FSI) {
                 para_level
             } else {
-                match initial_classes[end..].iter().position(not_removed_by_x9) {
+                match original_classes[end..].iter().position(not_removed_by_x9) {
                     Some(idx) => levels[idx],
                     None => para_level,
                 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -84,7 +84,8 @@ fn test_basic_conformance() {
 
                 // Check levels
                 let exp_levels: Vec<String> = exp_levels.iter().map(|x| x.to_owned()).collect();
-                let levels = gen_levels_list_from_bidi_info(&input_string, &bidi_info);
+                let para = &bidi_info.paragraphs[0];
+                let levels = bidi_info.reordered_levels_per_char(para, para.range.clone());
                 if levels != exp_levels {
                     fails.push(
                         Fail {
@@ -181,7 +182,8 @@ fn test_character_conformance() {
             let bidi_info = BidiInfo::new(&input_string, input_base_level);
 
             // Check levels
-            let levels = gen_levels_list_from_bidi_info(&input_string, &bidi_info);
+            let para = &bidi_info.paragraphs[0];
+            let levels = bidi_info.reordered_levels_per_char(para, para.range.clone());
             if levels != exp_levels {
                 fails.push(
                     Fail {
@@ -236,14 +238,6 @@ fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
 }
 
 
-/// We need to collaps levels to one-per-character from one-per-byte format.
-fn gen_levels_list_from_bidi_info(input_str: &str, bidi_info: &BidiInfo) -> Vec<Level> {
-    let para = &bidi_info.paragraphs[0];
-    let levels = bidi_info.reordered_levels(para, para.range.clone());
-    // TODO: Move to impl BidiInfo as pub api
-    input_str.char_indices().map(|(i, _)| levels[i]).collect()
-}
-
 fn get_sample_string_from_bidi_classes(class_names: &[&str]) -> String {
     class_names
         .iter()
@@ -251,7 +245,6 @@ fn get_sample_string_from_bidi_classes(class_names: &[&str]) -> String {
         .collect()
 }
 
-/// TODO: Auto-gen in tables.rs ?
 fn gen_char_from_bidi_class(class_name: &str) -> char {
     match class_name {
         "AL" => '\u{060B}',

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -130,6 +130,19 @@ fn test_basic_conformance() {
     }
 }
 
+// TODO: Support auto-RTL
+fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
+    /// Values: auto-LTR, LTR, RTL
+    const VALUES: &'static [Option<Level>] =
+        &[None, Some(level::LTR_LEVEL), Some(level::RTL_LEVEL)];
+    assert!(bitset < (1 << VALUES.len()));
+    (0..VALUES.len())
+        .filter(|bit| bitset & (1u8 << bit) == 1)
+        .map(|idx| VALUES[idx])
+        .collect()
+}
+
+
 #[test]
 #[should_panic(expected = "14558 test cases failed! (77141 passed)")]
 fn test_character_conformance() {
@@ -214,18 +227,6 @@ fn test_character_conformance() {
 }
 
 // TODO: Support auto-RTL
-fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
-    /// Values: auto-LTR, LTR, RTL
-    const VALUES: &'static [Option<Level>] =
-        &[None, Some(level::LTR_LEVEL), Some(level::RTL_LEVEL)];
-    assert!(bitset < (1 << VALUES.len()));
-    (0..VALUES.len())
-        .filter(|bit| bitset & (1u8 << bit) == 1)
-        .map(|idx| VALUES[idx])
-        .collect()
-}
-
-// TODO: Support auto-RTL
 fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
     /// Values: LTR, RTL, auto-LTR
     const VALUES: &'static [Option<Level>] =
@@ -233,6 +234,7 @@ fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
     assert!(idx < VALUES.len());
     VALUES[idx]
 }
+
 
 /// We need to collaps levels to one-per-character from one-per-byte format.
 fn gen_levels_list_from_bidi_info(input_str: &str, bidi_info: &BidiInfo) -> Vec<Level> {

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -28,7 +28,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "250 test cases failed! (256497 passed)")]
+#[should_panic(expected = "314 test cases failed! (256433 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 
@@ -254,29 +254,29 @@ fn get_sample_string_from_bidi_classes(class_names: &[&str]) -> String {
 /// TODO: Auto-gen in tables.rs ?
 fn gen_char_from_bidi_class(class_name: &str) -> char {
     match class_name {
-        "AL" => '\u{060b}',
+        "AL" => '\u{060B}',
         "AN" => '\u{0605}',
-        "B" => '\u{000a}',
-        "BN" => '\u{0000}',
-        "CS" => '\u{002c}',
-        "EN" => '\u{0039}',
-        "ES" => '\u{002b}',
-        "ET" => '\u{0023}',
+        "B" => '\u{000A}',
+        "BN" => '\u{2060}',
+        "CS" => '\u{2044}',
+        "EN" => '\u{06F9}',
+        "ES" => '\u{208B}',
+        "ET" => '\u{20CF}',
         "FSI" => format_chars::FSI,
-        "L" => '\u{0041}',
+        "L" => '\u{02B8}',
         "LRE" => format_chars::LRE,
         "LRI" => format_chars::LRI,
         "LRO" => format_chars::LRO,
         "NSM" => '\u{0300}',
-        "ON" => '\u{0021}',
+        "ON" => '\u{03F6}',
         "PDF" => format_chars::PDF,
         "PDI" => format_chars::PDI,
         "R" => '\u{0590}',
         "RLE" => format_chars::RLE,
         "RLI" => format_chars::RLI,
         "RLO" => format_chars::RLO,
-        "S" => '\u{0009}',
-        "WS" => '\u{000c}',
+        "S" => '\u{001F}',
+        "WS" => '\u{200A}',
         &_ => panic!("Invalid Bidi_Class name: {}", class_name),
     }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -28,7 +28,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "12827 test cases failed! (243920 passed)")]
+#[should_panic(expected = "250 test cases failed! (256497 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 


### PR DESCRIPTION
## Improve basic conformance by fixing steps X10, N1/N2, L1

Continue my review of code based on spec and fix various steps that
drop the basic conformance failures from 12827 to 250.

* X10: Fix incorrect index for `succ_level` resolution (off by
`end_of_seq` because of sub-sequencing) and add unit tests from the spec
text, from both BD13 and X10 sections.

* N1/N2: Fix resetting rule for NI levels by definint `e`, as noted in
the spec.

* L1: Fix not resetting leading whitespace/formatting chars in a line.

## [tests/conformance] Use non-ASCII sample chars

* Use non-ASCII sample chars for `gen_char_from_bidi_class()`, which
increases the failure rate from 250 to 314.

## [lib] Impl BidiInfo.reordered_levels_per_char()

* This allows easier testing of the logic, specially having specific cases
from the conformance test as unit test, as corner bugs unfold.

## [lib] reorder_line(): Expand LTR-only shortcut condition

* There's almost no extra cost in expanding the shortcut condition to
check all the isolating run sequences to be LTR, if there's more than
one. This can prevent a bunch of string manipulation when all isolating
run sequences are LTR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/unicode-bidi/36)
<!-- Reviewable:end -->
