### PR TITLE
Improve CI and update serde feature name

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,4 +16,4 @@ test_script:
   - cargo doc   --verbose --all --no-deps
 
   - cargo test  --verbose --all
-  - cargo test  --verbose --all --features with_serde
+  - cargo test  --verbose --all --features serde

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,19 @@
+install:
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
+  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - rustc -V
+  - cargo -V
+  - git submodule update --init --recursive
+
+build: false
+
+environment:
+    RUST_BACKTRACE: full
+
+test_script:
+  - cargo build --verbose --all
+  - cargo doc   --verbose --all --no-deps
+
+  - cargo test  --verbose --all
+  - cargo test  --verbose --all --features with_serde

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 /data/
 /target/
+/*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,21 @@ notifications:
   email:
     on_success: never
 
+env:
+  - RUST_BACKTRACE=1
+
 script:
   - cargo build --verbose
   - cargo doc   --verbose --no-deps
 
-  - RUST_BACKTRACE=1 cargo test  --verbose
-  - RUST_BACKTRACE=1 cargo test  --verbose --features with_serde
+  - cargo test  --verbose
+  - cargo test  --verbose --features 'with_serde'
 
+  # Stop here if not running on nightly rust
   - if [ "$TRAVIS_RUST_VERSION" != "nightly" ] ; then exit ; fi
 
-  - RUST_BACKTRACE=1 cargo test --verbose --features bench_it
-  - RUST_BACKTRACE=1 cargo test --verbose --features flame_it
+  - cargo test  --verbose --features 'bench_it'
+  - cargo bench --verbose --features 'bench_it'
 
-  - cargo run --verbose --features flame_it --example flame_udhr
-
-  - cargo bench --verbose --features bench_it
+  - cargo test  --verbose --features 'flame_it'
+  - cargo run   --verbose --features 'flame_it' --example 'flame_udhr'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - cargo doc   --verbose --no-deps
 
   - cargo test  --verbose
+  - cargo test  --verbose --features 'serde'
   - cargo test  --verbose --features 'with_serde'
 
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ notifications:
     on_success: never
 
 env:
-  - RUST_BACKTRACE=1
+  global:
+    - RUST_BACKTRACE=full
 
 script:
   - cargo build --verbose
@@ -29,11 +30,10 @@ script:
   - cargo test  --verbose
   - cargo test  --verbose --features 'with_serde'
 
-  # Stop here if not running on nightly rust
-  - if [ "$TRAVIS_RUST_VERSION" != "nightly" ] ; then exit ; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+      cargo bench --verbose --features 'bench_it';
+    fi
 
-  - cargo test  --verbose --features 'bench_it'
-  - cargo bench --verbose --features 'bench_it'
-
-  - cargo test  --verbose --features 'flame_it'
-  - cargo run   --verbose --features 'flame_it' --example 'flame_udhr'
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+      cargo run   --verbose --features 'flame_it' --example 'flame_udhr';
+    fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ name = "unicode_bidi"
 flame = { version = "0.1", optional = true }
 flamer = { version = "0.1", optional = true }
 matches = "0.1"
-serde = {version = ">=0.8, <2.0", optional = true}
-serde_derive = {version = ">=0.8, <2.0", optional = true}
+serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
@@ -28,4 +27,4 @@ default = []
 unstable = []  # travis-cargo needs it
 bench_it = []
 flame_it = ["flame", "flamer"]
-with_serde = ["serde", "serde_derive"]
+with_serde = ["serde"]  # DEPRECATED, please use `serde` feature, instead.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ compatible with the current stable release.
 
 [Documentation](http://doc.servo.org/unicode_bidi/)
 
-[![Build Status](https://travis-ci.org/servo/unicode-bidi.svg?branch=master)](https://travis-ci.org/servo/unicode-bidi)
+[![Travis-CI](https://travis-ci.org/servo/unicode-bidi.svg?branch=master)](https://travis-ci.org/servo/unicode-bidi)
+[![AppVeyor](https://img.shields.io/appveyor/ci/servo/unicode-bidi/master.svg)](https://ci.appveyor.com/project/servo/unicode-bidi)
 
 [tr9]: http://www.unicode.org/reports/tr9/

--- a/examples/flame_udhr.rs
+++ b/examples/flame_udhr.rs
@@ -29,7 +29,7 @@ use unicode_bidi::BidiInfo;
 
 #[cfg(feature = "flame_it")]
 fn main() {
-    const BIDI_TEXT: str = include_str!("../data/udhr/bidi/udhr_pes_1.txt");
+    const BIDI_TEXT: &str = include_str!("../data/udhr/bidi/udhr_pes_1.txt");
 
     flame::start("main(): BidiInfo::new()");
     let bidi_info = BidiInfo::new(BIDI_TEXT, None);

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -107,7 +107,8 @@ mod tests {
                 (0x1EEFF, AL),
                 (0x1EF00, R),
                 (0x1EFFF, R),
-            ] {
+            ]
+        {
             assert_eq!(bidi_class(char::from_u32(input).unwrap()), expected);
         }
     }

--- a/src/char_data/tables.rs
+++ b/src/char_data/tables.rs
@@ -10,11 +10,11 @@ pub const UNICODE_VERSION: (u64, u64, u64) = (9, 0, 0);
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Represents values of the Unicode character property
-/// [Bidi_Class](http://www.unicode.org/reports/tr44/#Bidi_Class), also
+/// [`Bidi_Class`](http://www.unicode.org/reports/tr44/#Bidi_Class), also
 /// known as the *bidirectional character type*.
 ///
-/// * http://www.unicode.org/reports/tr9/#Bidirectional_Character_Types
-/// * http://www.unicode.org/reports/tr44/#Bidi_Class_Values
+/// * <http://www.unicode.org/reports/tr9/#Bidirectional_Character_Types>
+/// * <http://www.unicode.org/reports/tr44/#Bidi_Class_Values>
 pub enum BidiClass {
     AL,
     AN,

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -79,9 +79,9 @@ pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
 
             seq_start = seq_end;
         }
-        max_level.lower(1).expect(
-            "Lowering embedding level below zero",
-        );
+        max_level
+            .lower(1)
+            .expect("Lowering embedding level below zero");
     }
 
     runs

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -81,9 +81,9 @@ pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
 
             seq_start = seq_end;
         }
-        max_level
-            .lower(1)
-            .expect("Lowering embedding level below zero");
+        max_level.lower(1).expect(
+            "Lowering embedding level below zero",
+        );
     }
 
     runs

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -9,6 +9,9 @@
 
 //! This module holds deprecated assets only.
 
+// Doesn't worth updating API here
+#![cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
+
 use super::*;
 
 /// Find the level runs within a line and return them in visual order.
@@ -20,7 +23,7 @@ use super::*;
 ///
 /// `line` is a range of bytes indices within `levels`.
 ///
-/// http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels
+/// <http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels>
 #[deprecated(since = "0.3.0", note = "please use `BidiInfo::visual_runs()` instead.")]
 pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
     assert!(line.start <= levels.len());
@@ -30,20 +33,19 @@ pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
 
     // Find consecutive level runs.
     let mut start = line.start;
-    let mut level = levels[start];
-    let mut min_level = level;
-    let mut max_level = level;
+    let mut run_level = levels[start];
+    let mut min_level = run_level;
+    let mut max_level = run_level;
 
-    for i in (start + 1)..line.end {
-        let new_level = levels[i];
-        if new_level != level {
+    for (i, &new_level) in levels.iter().enumerate().take(line.end).skip(start + 1) {
+        if new_level != run_level {
             // End of the previous run, start of a new one.
             runs.push(start..i);
             start = i;
-            level = new_level;
+            run_level = new_level;
 
-            min_level = min(level, min_level);
-            max_level = max(level, max_level);
+            min_level = min(run_level, min_level);
+            max_level = max(run_level, max_level);
         }
     }
     runs.push(start..line.end);
@@ -51,7 +53,7 @@ pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
     let run_count = runs.len();
 
     // Re-order the odd runs.
-    // http://www.unicode.org/reports/tr9/#L2
+    // <http://www.unicode.org/reports/tr9/#L2>
 
     // Stop at the lowest *odd* level.
     min_level = min_level.new_lowest_ge_rtl().expect("Level error");

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -9,7 +9,7 @@
 
 //! 3.3.2 Explicit Levels and Directions
 //!
-//! http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions
+//! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
 use super::char_data::{BidiClass, is_rtl};
 use super::level::Level;
@@ -30,7 +30,7 @@ pub fn compute(
 ) {
     assert_eq!(text.len(), original_classes.len());
 
-    // http://www.unicode.org/reports/tr9/#X1
+    // <http://www.unicode.org/reports/tr9/#X1>
     let mut stack = DirectionalStatusStack::new();
     stack.push(para_level, OverrideStatus::Neutral);
 
@@ -88,7 +88,7 @@ pub fn compute(
                 }
             }
 
-            // http://www.unicode.org/reports/tr9/#X6a
+            // <http://www.unicode.org/reports/tr9/#X6a>
             PDI => {
                 if overflow_isolate_count > 0 {
                     overflow_isolate_count -= 1;
@@ -113,7 +113,7 @@ pub fn compute(
                 }
             }
 
-            // http://www.unicode.org/reports/tr9/#X7
+            // <http://www.unicode.org/reports/tr9/#X7>
             PDF => {
                 if overflow_isolate_count > 0 {
                     continue;
@@ -133,7 +133,7 @@ pub fn compute(
             // Nothing
             B | BN => {}
 
-            // http://www.unicode.org/reports/tr9/#X6
+            // <http://www.unicode.org/reports/tr9/#X6>
             _ => {
                 let last = stack.last();
                 levels[i] = last.level;

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -20,7 +20,7 @@ use BidiClass::*;
 ///
 /// `processing_classes[i]` must contain the `BidiClass` of the char at byte index `i`,
 /// for each char in `text`.
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 pub fn compute(
     text: &str,
     para_level: Level,
@@ -62,7 +62,8 @@ pub fn compute(
                     last_level.new_explicit_next_ltr()
                 };
                 if new_level.is_ok() && overflow_isolate_count == 0 &&
-                   overflow_embedding_count == 0 {
+                    overflow_embedding_count == 0
+                {
                     let new_level = new_level.unwrap();
                     stack.push(
                         new_level,

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -177,10 +177,7 @@ impl DirectionalStatusStack {
     }
 
     fn push(&mut self, level: Level, status: OverrideStatus) {
-        self.vec.push(Status {
-            level,
-            status,
-        });
+        self.vec.push(Status { level, status });
     }
 
     fn last(&self) -> &Status {

--- a/src/format_chars.rs
+++ b/src/format_chars.rs
@@ -9,7 +9,7 @@
 
 //! Directional Formatting Characters
 //!
-//! http://www.unicode.org/reports/tr9/#Directional_Formatting_Characters
+//! <http://www.unicode.org/reports/tr9/#Directional_Formatting_Characters>
 
 // == Implicit ==
 /// ARABIC LETTER MARK

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -20,7 +20,7 @@ use BidiClass::*;
 /// 3.3.4 Resolving Weak Types
 ///
 /// http://www.unicode.org/reports/tr9/#Resolving_Weak_Types
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [BidiClass]) {
     // FIXME (#8): This function applies steps W1-W6 in a single pass.  This can produce
     // incorrect results in cases where a "later" rule changes the value of `prev_class` seen
@@ -38,9 +38,11 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
     fn id(x: LevelRun) -> LevelRun {
         x
     }
-    let mut indices = sequence.runs.iter().cloned().flat_map(
-        id as fn(LevelRun) -> LevelRun,
-    );
+    let mut indices = sequence
+        .runs
+        .iter()
+        .cloned()
+        .flat_map(id as fn(LevelRun) -> LevelRun);
 
     while let Some(i) = indices.next() {
         match processing_classes[i] {
@@ -135,7 +137,7 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
 /// 3.3.5 Resolving Neutral Types
 ///
 /// http://www.unicode.org/reports/tr9/#Resolving_Neutral_Types
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 pub fn resolve_neutral(
     sequence: &IsolatingRunSequence,
     levels: &[Level],
@@ -200,7 +202,7 @@ pub fn resolve_neutral(
 /// Returns the maximum embedding level in the paragraph.
 ///
 /// http://www.unicode.org/reports/tr9/#Resolving_Implicit_Levels
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> Level {
     let mut max_level = Level::ltr();
 

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -19,7 +19,7 @@ use BidiClass::*;
 
 /// 3.3.4 Resolving Weak Types
 ///
-/// http://www.unicode.org/reports/tr9/#Resolving_Weak_Types
+/// <http://www.unicode.org/reports/tr9/#Resolving_Weak_Types>
 #[cfg_attr(feature = "flame_it", flame)]
 pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [BidiClass]) {
     // FIXME (#8): This function applies steps W1-W6 in a single pass.  This can produce
@@ -46,7 +46,7 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
 
     while let Some(i) = indices.next() {
         match processing_classes[i] {
-            // http://www.unicode.org/reports/tr9/#W1
+            // <http://www.unicode.org/reports/tr9/#W1>
             NSM => {
                 processing_classes[i] = match prev_class {
                     RLI | LRI | FSI | PDI => ON,
@@ -65,10 +65,10 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
                     et_run_indices.clear();
                 }
             }
-            // http://www.unicode.org/reports/tr9/#W3
+            // <http://www.unicode.org/reports/tr9/#W3>
             AL => processing_classes[i] = R,
 
-            // http://www.unicode.org/reports/tr9/#W4
+            // <http://www.unicode.org/reports/tr9/#W4>
             ES | CS => {
                 let next_class = indices
                     .clone()
@@ -81,7 +81,7 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
                     (_, _, _) => ON,
                 }
             }
-            // http://www.unicode.org/reports/tr9/#W5
+            // <http://www.unicode.org/reports/tr9/#W5>
             ET => {
                 match prev_class {
                     EN => processing_classes[i] = EN,
@@ -136,7 +136,7 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
 
 /// 3.3.5 Resolving Neutral Types
 ///
-/// http://www.unicode.org/reports/tr9/#Resolving_Neutral_Types
+/// <http://www.unicode.org/reports/tr9/#Resolving_Neutral_Types>
 #[cfg_attr(feature = "flame_it", flame)]
 pub fn resolve_neutral(
     sequence: &IsolatingRunSequence,
@@ -180,8 +180,8 @@ pub fn resolve_neutral(
 
             // N1-N2.
             //
-            // http://www.unicode.org/reports/tr9/#N1
-            // http://www.unicode.org/reports/tr9/#N2
+            // <http://www.unicode.org/reports/tr9/#N1>
+            // <http://www.unicode.org/reports/tr9/#N2>
             let new_class = match (prev_class, next_class) {
                 (L, L) => L,
                 (R, R) | (R, AN) | (R, EN) | (AN, R) | (AN, AN) | (AN, EN) | (EN, R) |
@@ -201,7 +201,7 @@ pub fn resolve_neutral(
 ///
 /// Returns the maximum embedding level in the paragraph.
 ///
-/// http://www.unicode.org/reports/tr9/#Resolving_Implicit_Levels
+/// <http://www.unicode.org/reports/tr9/#Resolving_Implicit_Levels>
 #[cfg_attr(feature = "flame_it", flame)]
 pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> Level {
     let mut max_level = Level::ltr();
@@ -223,7 +223,7 @@ pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> L
 
 /// Neutral or Isolate formatting character (B, S, WS, ON, FSI, LRI, RLI, PDI)
 ///
-/// http://www.unicode.org/reports/tr9/#NI
+/// <http://www.unicode.org/reports/tr9/#NI>
 #[allow(non_snake_case)]
 fn is_NI(class: BidiClass) -> bool {
     matches!(class, B | S | WS | ON | FSI | LRI | RLI | PDI)

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -38,11 +38,9 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
     fn id(x: LevelRun) -> LevelRun {
         x
     }
-    let mut indices = sequence
-        .runs
-        .iter()
-        .cloned()
-        .flat_map(id as fn(LevelRun) -> LevelRun);
+    let mut indices = sequence.runs.iter().cloned().flat_map(
+        id as fn(LevelRun) -> LevelRun,
+    );
 
     while let Some(i) = indices.next() {
         match processing_classes[i] {

--- a/src/level.rs
+++ b/src/level.rs
@@ -28,7 +28,7 @@ use super::char_data::BidiClass;
 ///
 /// <http://www.unicode.org/reports/tr9/#BD2>
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Level(u8);
 
 pub const LTR_LEVEL: Level = Level(0);
@@ -354,7 +354,7 @@ mod tests {
     }
 }
 
-#[cfg(all(feature = "with_serde", test))]
+#[cfg(all(feature = "serde", test))]
 mod serde_tests {
     use serde_test::{Token, assert_tokens};
     use super::*;

--- a/src/level.rs
+++ b/src/level.rs
@@ -11,7 +11,7 @@
 //!
 //! See [`Level`](struct.Level.html) for more details.
 //!
-//! http://www.unicode.org/reports/tr9/#BD2
+//! <http://www.unicode.org/reports/tr9/#BD2>
 
 use std::convert::{From, Into};
 
@@ -26,7 +26,7 @@ use super::char_data::BidiClass;
 /// mutating an existing level, with the value smaller than `0` (before conversion to `u8`) or
 /// larger than 125 results in an `Error`.
 ///
-/// http://www.unicode.org/reports/tr9/#BD2
+/// <http://www.unicode.org/reports/tr9/#BD2>
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 pub struct Level(u8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,11 @@
 #[macro_use]
 extern crate matches;
 
-#[cfg(feature = "with_serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
-#[cfg(all(feature = "with_serde", test))]
+#[cfg(all(feature = "serde", test))]
 extern crate serde_test;
 
 #[cfg(feature = "flame_it")]
@@ -847,7 +847,7 @@ mod tests {
 }
 
 
-#[cfg(all(feature = "with_serde", test))]
+#[cfg(all(feature = "serde", test))]
 mod serde_tests {
     use serde_test::{Token, assert_tokens};
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ extern crate serde_derive;
 #[cfg(all(feature = "with_serde", test))]
 extern crate serde_test;
 
-#[cfg(feature="flame_it")]
+#[cfg(feature = "flame_it")]
 extern crate flame;
 
 
@@ -135,7 +135,7 @@ impl<'text> InitialInfo<'text> {
     /// Also sets the class for each First Strong Isolate initiator (FSI) to LRI or RLI if a strong
     /// character is found before the matching PDI.  If no strong character is found, the class will
     /// remain FSI, and it's up to later stages to treat these as LRI when needed.
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn new(text: &str, default_para_level: Option<Level>) -> InitialInfo {
         let mut original_classes = Vec::with_capacity(text.len());
 
@@ -146,19 +146,16 @@ impl<'text> InitialInfo<'text> {
         let mut para_start = 0;
         let mut para_level = default_para_level;
 
-        #[cfg(feature="flame_it")]
-        flame::start("InitialInfo::new(): iter text.char_indices()");
+        #[cfg(feature = "flame_it")] flame::start("InitialInfo::new(): iter text.char_indices()");
 
         for (i, c) in text.char_indices() {
             let class = bidi_class(c);
 
-            #[cfg(feature="flame_it")]
-            flame::start("original_classes.extend()");
+            #[cfg(feature = "flame_it")] flame::start("original_classes.extend()");
 
             original_classes.extend(repeat(class).take(c.len_utf8()));
 
-            #[cfg(feature="flame_it")]
-            flame::end("original_classes.extend()");
+            #[cfg(feature = "flame_it")] flame::end("original_classes.extend()");
 
             match class {
 
@@ -223,8 +220,7 @@ impl<'text> InitialInfo<'text> {
         }
         assert_eq!(original_classes.len(), text.len());
 
-        #[cfg(feature="flame_it")]
-        flame::end("InitialInfo::new(): iter text.char_indices()");
+        #[cfg(feature = "flame_it")] flame::end("InitialInfo::new(): iter text.char_indices()");
 
         InitialInfo {
             text,
@@ -265,7 +261,7 @@ impl<'text> BidiInfo<'text> {
     /// text that is entirely LTR.  See the `nsBidi` class from Gecko for comparison.
     ///
     /// TODO: Support auto-RTL base direction
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn new(text: &str, default_para_level: Option<Level>) -> BidiInfo {
         let InitialInfo {
             original_classes,
@@ -313,7 +309,7 @@ impl<'text> BidiInfo<'text> {
 
     /// Re-order a line based on resolved levels and return only the embedding levels, one `Level`
     /// per *byte*.
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn reordered_levels(&self, para: &ParagraphInfo, line: Range<usize>) -> Vec<Level> {
         let (levels, _) = self.visual_runs(para, line.clone());
         levels
@@ -321,7 +317,7 @@ impl<'text> BidiInfo<'text> {
 
     /// Re-order a line based on resolved levels and return only the embedding levels, one `Level`
     /// per *character*.
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn reordered_levels_per_char(
         &self,
         para: &ParagraphInfo,
@@ -333,7 +329,7 @@ impl<'text> BidiInfo<'text> {
 
 
     /// Re-order a line based on resolved levels and return the line in display order.
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn reorder_line(&self, para: &ParagraphInfo, line: Range<usize>) -> Cow<'text, str> {
         let (levels, runs) = self.visual_runs(para, line.clone());
 
@@ -358,7 +354,7 @@ impl<'text> BidiInfo<'text> {
     /// `line` is a range of bytes indices within `levels`.
     ///
     /// http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels
-    #[cfg_attr(feature="flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame)]
     pub fn visual_runs(
         &self,
         para: &ParagraphInfo,
@@ -462,9 +458,9 @@ impl<'text> BidiInfo<'text> {
 
                 seq_start = seq_end;
             }
-            max_level.lower(1).expect(
-                "Lowering embedding level below zero",
-            );
+            max_level
+                .lower(1)
+                .expect("Lowering embedding level below zero");
         }
 
         (levels, runs)
@@ -483,7 +479,7 @@ impl<'text> BidiInfo<'text> {
 ///
 /// The levels assigned to these characters are not specified by the algorithm.  This function
 /// assigns each one the level of the previous character, to avoid breaking level runs.
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 fn assign_levels_to_removed_chars(para_level: Level, classes: &[BidiClass], levels: &mut [Level]) {
     for i in 0..levels.len() {
         if prepare::removed_by_x9(classes[i]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ impl<'text> BidiInfo<'text> {
                 }
             }
             if let (Some(from), Some(to)) = (reset_from, reset_to) {
-                #[cfg_attr(feature="cargo-clippy", allow(needless_range_loop))]
+                #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
                 for j in from..to {
                     levels[j] = para.level;
                 }
@@ -402,7 +402,7 @@ impl<'text> BidiInfo<'text> {
             }
         }
         if let Some(from) = reset_from {
-            #[cfg_attr(feature="cargo-clippy", allow(needless_range_loop))]
+            #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
             for j in from..line_str.len() {
                 levels[j] = para.level;
             }
@@ -458,9 +458,9 @@ impl<'text> BidiInfo<'text> {
 
                 seq_start = seq_end;
             }
-            max_level
-                .lower(1)
-                .expect("Lowering embedding level below zero");
+            max_level.lower(1).expect(
+                "Lowering embedding level below zero",
+            );
         }
 
         (levels, runs)

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -41,7 +41,7 @@ pub struct IsolatingRunSequence {
 /// whose matching PDI is the first character of the next level run in the sequence.
 ///
 /// Note: This function does *not* return the sequences in order by their first characters.
-#[cfg_attr(feature="flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flame)]
 pub fn isolating_run_sequences(
     para_level: Level,
     original_classes: &[BidiClass],
@@ -106,9 +106,9 @@ pub fn isolating_run_sequences(
             }
 
             // Get the level of the last non-removed char before the runs.
-            let pred_level = match original_classes[..start_of_seq].iter().rposition(
-                not_removed_by_x9,
-            ) {
+            let pred_level = match original_classes[..start_of_seq]
+                .iter()
+                .rposition(not_removed_by_x9) {
                 Some(idx) => levels[idx],
                 None => para_level,
             };
@@ -117,9 +117,9 @@ pub fn isolating_run_sequences(
             let succ_level = if matches!(original_classes[end_of_seq - 1], RLI | LRI | FSI) {
                 para_level
             } else {
-                match original_classes[end_of_seq..].iter().position(
-                    not_removed_by_x9,
-                ) {
+                match original_classes[end_of_seq..]
+                    .iter()
+                    .position(not_removed_by_x9) {
                     Some(idx) => levels[end_of_seq + idx],
                     None => para_level,
                 }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -9,7 +9,7 @@
 
 //! 3.3.3 Preparations for Implicit Processing
 //!
-//! http://www.unicode.org/reports/tr9/#Preparations_for_Implicit_Processing
+//! <http://www.unicode.org/reports/tr9/#Preparations_for_Implicit_Processing>
 
 use std::cmp::max;
 use std::ops::Range;
@@ -50,7 +50,7 @@ pub fn isolating_run_sequences(
     let runs = level_runs(levels, original_classes);
 
     // Compute the set of isolating run sequences.
-    // http://www.unicode.org/reports/tr9/#BD13
+    // <http://www.unicode.org/reports/tr9/#BD13>
     let mut sequences = Vec::with_capacity(runs.len());
 
     // When we encounter an isolate initiator, we push the current sequence onto the
@@ -86,7 +86,7 @@ pub fn isolating_run_sequences(
     sequences.extend(stack.into_iter().rev().filter(|seq| !seq.is_empty()));
 
     // Determine the `sos` and `eos` class for each sequence.
-    // http://www.unicode.org/reports/tr9/#X10
+    // <http://www.unicode.org/reports/tr9/#X10>
     sequences
         .into_iter()
         .map(|sequence: Vec<LevelRun>| {
@@ -136,7 +136,7 @@ pub fn isolating_run_sequences(
 
 /// Finds the level runs in a paragraph.
 ///
-/// http://www.unicode.org/reports/tr9/#BD7
+/// <http://www.unicode.org/reports/tr9/#BD7>
 fn level_runs(levels: &[Level], original_classes: &[BidiClass]) -> Vec<LevelRun> {
     assert_eq!(levels.len(), original_classes.len());
 
@@ -162,7 +162,7 @@ fn level_runs(levels: &[Level], original_classes: &[BidiClass]) -> Vec<LevelRun>
 
 /// Should this character be ignored in steps after X9?
 ///
-/// http://www.unicode.org/reports/tr9/#X9
+/// <http://www.unicode.org/reports/tr9/#X9>
 pub fn removed_by_x9(class: BidiClass) -> bool {
     matches!(class, RLE | LRE | RLO | LRO | PDF | BN)
 }
@@ -185,7 +185,7 @@ mod tests {
         );
     }
 
-    // From http://www.unicode.org/reports/tr9/#BD13
+    // From <http://www.unicode.org/reports/tr9/#BD13>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     #[test]
     fn test_isolating_run_sequences() {
@@ -230,7 +230,7 @@ mod tests {
         );
     }
 
-    // From http://www.unicode.org/reports/tr9/#X10
+    // From <http://www.unicode.org/reports/tr9/#X10>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     #[test]
     fn test_isolating_run_sequences_sos_and_eos() {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -106,9 +106,9 @@ pub fn isolating_run_sequences(
             }
 
             // Get the level of the last non-removed char before the runs.
-            let pred_level = match original_classes[..start_of_seq]
-                .iter()
-                .rposition(not_removed_by_x9) {
+            let pred_level = match original_classes[..start_of_seq].iter().rposition(
+                not_removed_by_x9,
+            ) {
                 Some(idx) => levels[idx],
                 None => para_level,
             };
@@ -117,9 +117,9 @@ pub fn isolating_run_sequences(
             let succ_level = if matches!(original_classes[end_of_seq - 1], RLI | LRI | FSI) {
                 para_level
             } else {
-                match original_classes[end_of_seq..]
-                    .iter()
-                    .position(not_removed_by_x9) {
+                match original_classes[end_of_seq..].iter().position(
+                    not_removed_by_x9,
+                ) {
                     Some(idx) => levels[end_of_seq + idx],
                     None => para_level,
                 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -297,7 +297,8 @@ fn test_gen_char_from_bidi_class() {
         RLO,
         S,
         WS,
-    ] {
+    ]
+    {
         let class_name = format!("{:?}", class);
         let sample_char = gen_char_from_bidi_class(&class_name);
         assert_eq!(bidi_class(sample_char), class);

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -132,8 +132,7 @@ fn test_basic_conformance() {
 // TODO: Support auto-RTL
 fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
     /// Values: auto-LTR, LTR, RTL
-    const VALUES: &[Option<Level>] =
-        &[None, Some(level::LTR_LEVEL), Some(level::RTL_LEVEL)];
+    const VALUES: &[Option<Level>] = &[None, Some(level::LTR_LEVEL), Some(level::RTL_LEVEL)];
     assert!(bitset < (1 << VALUES.len()));
     (0..VALUES.len())
         .filter(|bit| bitset & (1u8 << bit) == 1)
@@ -227,8 +226,7 @@ fn test_character_conformance() {
 // TODO: Support auto-RTL
 fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
     /// Values: LTR, RTL, auto-LTR
-    const VALUES: &[Option<Level>] =
-        &[Some(level::LTR_LEVEL), Some(level::RTL_LEVEL), None];
+    const VALUES: &[Option<Level>] = &[Some(level::LTR_LEVEL), Some(level::RTL_LEVEL), None];
     assert!(idx < VALUES.len());
     VALUES[idx]
 }

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -4,8 +4,7 @@
 #
 # Copyright 2011-2013 The Rust Project Developers.
 # Copyright 2015 The Servo Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
+# file at the top-level directory of this distribution.
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 # http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -88,7 +87,7 @@ def load_unicode_data():
         bidi_class[bidi].append(code)
 
     # Default Bidi_Class for unassigned codepoints.
-    # http://www.unicode.org/Public/UNIDATA/extracted/DerivedBidiClass.txt
+    # <http://www.unicode.org/Public/UNIDATA/extracted/DerivedBidiClass.txt>
     default_ranges = [
         (0x0600, 0x07BF, "AL"), (0x08A0, 0x08FF, "AL"),
         (0xFB50, 0xFDCF, "AL"), (0xFDF0, 0xFDFF, "AL"),
@@ -176,11 +175,11 @@ def emit_bidi_module(file_, bidi_class_table, cats):
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Represents values of the Unicode character property
-/// [Bidi_Class](http://www.unicode.org/reports/tr44/#Bidi_Class), also
+/// [`Bidi_Class`](http://www.unicode.org/reports/tr44/#Bidi_Class), also
 /// known as the *bidirectional character type*.
 ///
-/// * http://www.unicode.org/reports/tr9/#Bidirectional_Character_Types
-/// * http://www.unicode.org/reports/tr44/#Bidi_Class_Values
+/// * <http://www.unicode.org/reports/tr9/#Bidirectional_Character_Types>
+/// * <http://www.unicode.org/reports/tr44/#Bidi_Class_Values>
 pub enum BidiClass {
 """)
     for cat in cats:


### PR DESCRIPTION
Summary: Development improvements, with no API or functionality changes.

* We already follow most of the items from the [Rust API guildeline](https://github.com/brson/rust-api-guidelines). In this stack, I fix one case that's fairly trivial and easily backward-compatible: use `serde` as feature name for enabling serde, instead of home-brew `with_serde`.

* The shortcut I put in `travis.yml` script section was causing false positives in 100% of executions (oops!), which is now fixed by a more verbose conditioning, but accurate.

* Add `appveyor.yml`, as many packages depending on this package already require stable windows builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/unicode-bidi/42)
<!-- Reviewable:end -->
