### PR TITLE
Add readme field to Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"
 repository = "https://github.com/servo/unicode-bidi"
-documentation = "http://doc.servo.org/unicode_bidi/"
+documentation = "https://docs.rs/unicode-bidi/"
 keywords = ["rtl", "unicode", "text", "layout", "bidi"]
 readme="README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Implementation of the Unicode Bidirectional Algorithm"
 repository = "https://github.com/servo/unicode-bidi"
 documentation = "http://doc.servo.org/unicode_bidi/"
 keywords = ["rtl", "unicode", "text", "layout", "bidi"]
+readme="README.md"
 
 # No data is shipped; benches, examples and tests also depend on data.
 exclude = [

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This crate implements the [Unicode Bidirectional Algorithm][tr9] for display
 of mixed right-to-left and left-to-right text.  It is written in safe Rust,
 compatible with the current stable release.
 
-[Documentation](http://doc.servo.org/unicode_bidi/)
+[Documentation](https://docs.rs/unicode-bidi/)
 
 [![Travis-CI](https://travis-ci.org/servo/unicode-bidi.svg?branch=master)](https://travis-ci.org/servo/unicode-bidi)
 [![AppVeyor](https://img.shields.io/appveyor/ci/servo/unicode-bidi/master.svg)](https://ci.appveyor.com/project/servo/unicode-bidi)


### PR DESCRIPTION
This will cause the README file to be displayed on crates.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/unicode-bidi/49)
<!-- Reviewable:end -->
