### PR TITLE
remove matches dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ name = "unicode_bidi"
 [dependencies]
 flame = { version = "0.1", optional = true }
 flamer = { version = "0.1", optional = true }
-matches = "0.1"
 serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,6 @@
 #![cfg_attr(feature="flame_it", feature(plugin, custom_attribute))]
 #![cfg_attr(feature="flame_it", plugin(flamer))]
 
-
-#[macro_use]
-extern crate matches;
-
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
The matches macro is stabilized in `std` [since 1.42.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1420-2020-03-12).