### PR TITLE
Apply visual run resets to line range.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,6 +364,8 @@ impl<'text> BidiInfo<'text> {
         assert!(line.end <= self.levels.len());
 
         let mut levels = self.levels.clone();
+        let line_classes = &self.original_classes[line.clone()];
+        let line_levels = &mut levels[line.clone()];
 
         // Reset some whitespace chars to paragraph level.
         // <http://www.unicode.org/reports/tr9/#L1>
@@ -371,7 +373,7 @@ impl<'text> BidiInfo<'text> {
         let mut reset_from: Option<usize> = Some(0);
         let mut reset_to: Option<usize> = None;
         for (i, c) in line_str.char_indices() {
-            match self.original_classes[i] {
+            match line_classes[i] {
                 // Ignored by X9
                 RLE | LRE | RLO | LRO | PDF | BN => {}
                 // Segment separator, Paragraph separator
@@ -395,7 +397,7 @@ impl<'text> BidiInfo<'text> {
             if let (Some(from), Some(to)) = (reset_from, reset_to) {
                 #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
                 for j in from..to {
-                    levels[j] = para.level;
+                    line_levels[j] = para.level;
                 }
                 reset_from = None;
                 reset_to = None;
@@ -404,7 +406,7 @@ impl<'text> BidiInfo<'text> {
         if let Some(from) = reset_from {
             #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
             for j in from..line_str.len() {
-                levels[j] = para.level;
+                line_levels[j] = para.level;
             }
         }
 
@@ -822,6 +824,13 @@ mod tests {
             reordered_levels_per_char_for_paras(text),
             vec![Level::vec(&[0, 0])]
         );
+
+        let text = "aa טֶ";
+        let bidi_info = BidiInfo::new(text, None);
+        assert_eq!(
+            bidi_info.reordered_levels(&bidi_info.paragraphs[0], 3..7),
+            Level::vec(&[0, 0, 0, 1, 1, 1, 1]),
+        )
 
         /* TODO
         /// BidiTest:69635 (AL ET EN)


### PR DESCRIPTION
The reset logic in visual runs doesn't take the line offset into account. The for loop iterates over the line's char indices, but the line-local index `i` is then used to index into the `original_classes` for the whole paragraph.

Consider the string `"aa טֶ"`, which consists of five chars with the following subranges:
- `0..1: a`
- `1..2: a`
- `2..3: space`
- `3..5: ט`
- `5..7: \u{5b6}`

What happens in detail: When resolving the line `3..7`, the code previously iterated over both chars, and for the last char `i=2` resolved to the original class of the space, setting `reset_from` to `Some(2)`. Then, all bytes from `2` to `line_str.len()` (which was `4`), were reset to paragraph level. As a result, the first half of `ט` was reset to `0`.

The result of all this is that the reordered visual runs now slice the `ט` in half because its level changes halfway through. In addition to a fix for the problem, I added the above example as a test case.