### PR TITLE
Update to 2018 edition and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.17.0
+  - 1.31.0
 
 matrix:
   fast_finish: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"
@@ -8,6 +8,7 @@ repository = "https://github.com/servo/unicode-bidi"
 documentation = "https://docs.rs/unicode-bidi/"
 keywords = ["rtl", "unicode", "text", "layout", "bidi"]
 readme="README.md"
+edition = "2018"
 
 # No data is shipped; benches, examples and tests also depend on data.
 exclude = [

--- a/examples/flame_udhr.rs
+++ b/examples/flame_udhr.rs
@@ -10,25 +10,14 @@
 
 //! Profiling example
 
-#![allow(unused_imports)]
-
 #![cfg_attr(feature="flame_it", feature(plugin, custom_attribute))]
 #![cfg_attr(feature="flame_it", plugin(flamer))]
 
-
-#[cfg(feature = "flame_it")]
-extern crate flame;
-
-extern crate unicode_bidi;
-
-
-use std::fs::File;
-
-use unicode_bidi::BidiInfo;
-
-
 #[cfg(feature = "flame_it")]
 fn main() {
+    use std::fs::File;
+    use unicode_bidi::BidiInfo;
+
     const BIDI_TEXT: &str = include_str!("../data/udhr/bidi/udhr_pes_1.txt");
 
     flame::start("main(): BidiInfo::new()");

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -17,7 +17,7 @@ use std::cmp::Ordering::{Equal, Less, Greater};
 use std::char;
 
 use self::tables::bidi_class_table;
-use BidiClass::*;
+use crate::BidiClass::*;
 
 /// Find the `BidiClass` of a single char.
 pub fn bidi_class(c: char) -> BidiClass {

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -9,9 +9,6 @@
 
 //! This module holds deprecated assets only.
 
-// Doesn't worth updating API here
-#![cfg_attr(feature="cargo-clippy", allow(needless_pass_by_value))]
-
 use super::*;
 
 /// Find the level runs within a line and return them in visual order.

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -11,10 +11,10 @@
 //!
 //! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
-use super::char_data::{BidiClass, is_rtl};
-use super::level::Level;
+use matches::matches;
 
-use BidiClass::*;
+use super::char_data::{BidiClass::{self, *}, is_rtl};
+use super::level::Level;
 
 /// Compute explicit embedding levels for one paragraph of text (X1-X8).
 ///

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -10,12 +10,11 @@
 //! 3.3.4 - 3.3.6. Resolve implicit levels and types.
 
 use std::cmp::max;
+use matches::matches;
 
-use super::char_data::BidiClass;
+use super::char_data::BidiClass::{self, *};
 use super::prepare::{IsolatingRunSequence, LevelRun, not_removed_by_x9, removed_by_x9};
 use super::level::Level;
-
-use BidiClass::*;
 
 /// 3.3.4 Resolving Weak Types
 ///

--- a/src/level.rs
+++ b/src/level.rs
@@ -28,7 +28,7 @@ use super::char_data::BidiClass;
 ///
 /// <http://www.unicode.org/reports/tr9/#BD2>
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Level(u8);
 
 pub const LTR_LEVEL: Level = Level(0);

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -13,11 +13,10 @@
 
 use std::cmp::max;
 use std::ops::Range;
+use matches::matches;
 
-use super::char_data::BidiClass;
+use super::BidiClass::{self, *};
 use super::level::Level;
-
-use BidiClass::*;
 
 /// A maximal substring of characters with the same embedding level.
 ///
@@ -186,7 +185,7 @@ mod tests {
     }
 
     // From <http://www.unicode.org/reports/tr9/#BD13>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn test_isolating_run_sequences() {
 
@@ -231,7 +230,7 @@ mod tests {
     }
 
     // From <http://www.unicode.org/reports/tr9/#X10>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn test_isolating_run_sequences_sos_and_eos() {
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -7,10 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg(test)]
-
-extern crate unicode_bidi;
-
 use unicode_bidi::{bidi_class, BidiInfo, format_chars, level, Level};
 
 #[derive(Debug)]


### PR DESCRIPTION
This increases the minimum supported Rust version from 1.17 to 1.31 (released in December 2018).  I hope this will have little impact on users, since this version of Rust is almost 2.5 years old, and because our main downstream crates (`url` and `postgres-protocol`) already require 1.31 or later.

Many of the changes below are fixing new rustc/clippy warnings added in recent toolchains.

r? @Manishearth 