### PR TITLE
Update to flame 0.2 and flamer 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ appveyor = { repository = "servo/unicode-bidi" }
 name = "unicode_bidi"
 
 [dependencies]
-flame = { version = "0.1", optional = true }
-flamer = { version = "0.1", optional = true }
+flame = { version = "0.2", optional = true }
+flamer = { version = "0.4", optional = true }
 matches = "0.1"
 serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
 

--- a/examples/flame_udhr.rs
+++ b/examples/flame_udhr.rs
@@ -10,9 +10,6 @@
 
 //! Profiling example
 
-#![cfg_attr(feature="flame_it", feature(plugin, custom_attribute))]
-#![cfg_attr(feature="flame_it", plugin(flamer))]
-
 #[cfg(feature = "flame_it")]
 fn main() {
     use std::fs::File;

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -20,7 +20,7 @@ use super::level::Level;
 ///
 /// `processing_classes[i]` must contain the `BidiClass` of the char at byte index `i`,
 /// for each char in `text`.
-#[cfg_attr(feature = "flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flamer::flame)]
 pub fn compute(
     text: &str,
     para_level: Level,

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -19,7 +19,7 @@ use super::level::Level;
 /// 3.3.4 Resolving Weak Types
 ///
 /// <http://www.unicode.org/reports/tr9/#Resolving_Weak_Types>
-#[cfg_attr(feature = "flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flamer::flame)]
 pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [BidiClass]) {
     // FIXME (#8): This function applies steps W1-W6 in a single pass.  This can produce
     // incorrect results in cases where a "later" rule changes the value of `prev_class` seen
@@ -134,7 +134,7 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
 /// 3.3.5 Resolving Neutral Types
 ///
 /// <http://www.unicode.org/reports/tr9/#Resolving_Neutral_Types>
-#[cfg_attr(feature = "flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flamer::flame)]
 pub fn resolve_neutral(
     sequence: &IsolatingRunSequence,
     levels: &[Level],
@@ -199,7 +199,7 @@ pub fn resolve_neutral(
 /// Returns the maximum embedding level in the paragraph.
 ///
 /// <http://www.unicode.org/reports/tr9/#Resolving_Implicit_Levels>
-#[cfg_attr(feature = "flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flamer::flame)]
 pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> Level {
     let mut max_level = Level::ltr();
 

--- a/src/level.rs
+++ b/src/level.rs
@@ -328,7 +328,8 @@ mod tests {
     #[test]
     fn test_into() {
         let level = Level::rtl();
-        assert_eq!(1u8, level.into());
+        let number: u8 = level.into();
+        assert_eq!(1u8, number);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,6 @@
 
 #![forbid(unsafe_code)]
 
-#![cfg_attr(feature="flame_it", feature(plugin, custom_attribute))]
-#![cfg_attr(feature="flame_it", plugin(flamer))]
-
 pub mod deprecated;
 pub mod format_chars;
 pub mod level;
@@ -119,7 +116,7 @@ impl<'text> InitialInfo<'text> {
     /// Also sets the class for each First Strong Isolate initiator (FSI) to LRI or RLI if a strong
     /// character is found before the matching PDI.  If no strong character is found, the class will
     /// remain FSI, and it's up to later stages to treat these as LRI when needed.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
     pub fn new(text: &str, default_para_level: Option<Level>) -> InitialInfo<'_> {
         let mut original_classes = Vec::with_capacity(text.len());
 
@@ -245,7 +242,7 @@ impl<'text> BidiInfo<'text> {
     /// text that is entirely LTR.  See the `nsBidi` class from Gecko for comparison.
     ///
     /// TODO: Support auto-RTL base direction
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
     pub fn new(text: &str, default_para_level: Option<Level>) -> BidiInfo<'_> {
         let InitialInfo {
             original_classes,
@@ -293,7 +290,7 @@ impl<'text> BidiInfo<'text> {
 
     /// Re-order a line based on resolved levels and return only the embedding levels, one `Level`
     /// per *byte*.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
     pub fn reordered_levels(&self, para: &ParagraphInfo, line: Range<usize>) -> Vec<Level> {
         let (levels, _) = self.visual_runs(para, line);
         levels
@@ -301,7 +298,7 @@ impl<'text> BidiInfo<'text> {
 
     /// Re-order a line based on resolved levels and return only the embedding levels, one `Level`
     /// per *character*.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
     pub fn reordered_levels_per_char(
         &self,
         para: &ParagraphInfo,
@@ -313,7 +310,7 @@ impl<'text> BidiInfo<'text> {
 
 
     /// Re-order a line based on resolved levels and return the line in display order.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
     pub fn reorder_line(&self, para: &ParagraphInfo, line: Range<usize>) -> Cow<'text, str> {
         let (levels, runs) = self.visual_runs(para, line.clone());
 
@@ -338,7 +335,7 @@ impl<'text> BidiInfo<'text> {
     /// `line` is a range of bytes indices within `levels`.
     ///
     /// <http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels>
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
     pub fn visual_runs(
         &self,
         para: &ParagraphInfo,
@@ -463,7 +460,7 @@ impl<'text> BidiInfo<'text> {
 ///
 /// The levels assigned to these characters are not specified by the algorithm.  This function
 /// assigns each one the level of the previous character, to avoid breaking level runs.
-#[cfg_attr(feature = "flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flamer::flame)]
 fn assign_levels_to_removed_chars(para_level: Level, classes: &[BidiClass], levels: &mut [Level]) {
     for i in 0..levels.len() {
         if prepare::removed_by_x9(classes[i]) {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -40,7 +40,7 @@ pub struct IsolatingRunSequence {
 /// whose matching PDI is the first character of the next level run in the sequence.
 ///
 /// Note: This function does *not* return the sequences in order by their first characters.
-#[cfg_attr(feature = "flame_it", flame)]
+#[cfg_attr(feature = "flame_it", flamer::flame)]
 pub fn isolating_run_sequences(
     para_level: Level,
     original_classes: &[BidiClass],


### PR DESCRIPTION
The old version was implemented as a compiler plugin for very old nightly rustc builds.  The new versions are compatible with stable Rust.

r? @Manishearth 