### PR TITLE
Add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,14 @@ name = "unicode_bidi"
 [dependencies]
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.4", optional = true }
-matches = "0.1"
 serde = { version = ">=0.8, <2.0", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
 
 [features]
+# Note: We don't actually use the `std` feature for anything other than making
+# doctests work. But it may come in handy in the future.
 default = ["std"]
 std = []
 unstable = []  # travis-cargo needs it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ documentation = "https://docs.rs/unicode-bidi/"
 keywords = ["rtl", "unicode", "text", "layout", "bidi"]
 readme="README.md"
 edition = "2018"
+categories = [
+    "no-std",
+    "encoding",
+    "text-processing",
+]
 
 # No data is shipped; benches, examples and tests also depend on data.
 exclude = [
@@ -30,13 +35,14 @@ name = "unicode_bidi"
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.4", optional = true }
 matches = "0.1"
-serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
+serde = { version = ">=0.8, <2.0", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
 
 [features]
-default = []
+default = ["std"]
+std = []
 unstable = []  # travis-cargo needs it
 bench_it = []
 flame_it = ["flame", "flamer"]

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -13,8 +13,8 @@ mod tables;
 
 pub use self::tables::{BidiClass, UNICODE_VERSION};
 
-use std::cmp::Ordering::{Equal, Less, Greater};
-use std::char;
+use core::cmp::Ordering::{Equal, Less, Greater};
+use core::char;
 
 use self::tables::bidi_class_table;
 use crate::BidiClass::*;

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -9,6 +9,8 @@
 
 //! This module holds deprecated assets only.
 
+use alloc::vec::Vec;
+
 use super::*;
 
 /// Find the level runs within a line and return them in visual order.

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -12,6 +12,7 @@
 //! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
 use matches::matches;
+use alloc::vec::Vec;
 
 use super::char_data::{BidiClass::{self, *}, is_rtl};
 use super::level::Level;

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -11,7 +11,6 @@
 //!
 //! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
-use matches::matches;
 use alloc::vec::Vec;
 
 use super::char_data::{BidiClass::{self, *}, is_rtl};
@@ -47,7 +46,10 @@ pub fn compute(
                 let last_level = stack.last().level;
 
                 // X5a-X5c: Isolate initiators get the level of the last entry on the stack.
-                let is_isolate = matches!(original_classes[i], RLI | LRI | FSI);
+                let is_isolate = match original_classes[i] {
+                    RLI | LRI | FSI => true,
+                    _ => false,
+                };
                 if is_isolate {
                     levels[i] = last_level;
                     match stack.last().status {

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -10,7 +10,6 @@
 //! 3.3.4 - 3.3.6. Resolve implicit levels and types.
 
 use core::cmp::max;
-use matches::matches;
 use alloc::vec::Vec;
 
 use super::char_data::BidiClass::{self, *};
@@ -224,5 +223,8 @@ pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> L
 /// <http://www.unicode.org/reports/tr9/#NI>
 #[allow(non_snake_case)]
 fn is_NI(class: BidiClass) -> bool {
-    matches!(class, B | S | WS | ON | FSI | LRI | RLI | PDI)
+    match class {
+        B | S | WS | ON | FSI | LRI | RLI | PDI => true,
+        _ => false,
+    }
 }

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -9,8 +9,9 @@
 
 //! 3.3.4 - 3.3.6. Resolve implicit levels and types.
 
-use std::cmp::max;
+use core::cmp::max;
 use matches::matches;
+use alloc::vec::Vec;
 
 use super::char_data::BidiClass::{self, *};
 use super::prepare::{IsolatingRunSequence, LevelRun, not_removed_by_x9, removed_by_x9};

--- a/src/level.rs
+++ b/src/level.rs
@@ -13,7 +13,9 @@
 //!
 //! <http://www.unicode.org/reports/tr9/#BD2>
 
-use std::convert::{From, Into};
+use alloc::vec::Vec;
+use core::convert::{From, Into};
+use alloc::string::{String, ToString};
 
 use super::char_data::BidiClass;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,23 @@
 //! ]);
 //! ```
 //!
+//! # Features
+//!
+//! - `std`: Enabled by default, but can be disabled to make `unicode_bidi`
+//!   `#![no_std]` + `alloc` compatible.
+//! - `serde`: Adds [`serde::Serialize`] and [`serde::Deserialize`]
+//!   implementations to relevant types.
+//!
 //! [tr9]: <http://www.unicode.org/reports/tr9/>
 
 #![forbid(unsafe_code)]
+
+#![no_std]
+// We need to link to std to make doc tests work on older Rust versions
+#![cfg(feature = "std")]
+extern crate std;
+#[macro_use]
+extern crate alloc;
 
 pub mod deprecated;
 pub mod format_chars;
@@ -70,10 +84,12 @@ pub use crate::char_data::{BidiClass, bidi_class, UNICODE_VERSION};
 pub use crate::level::{Level, LTR_LEVEL, RTL_LEVEL};
 pub use crate::prepare::LevelRun;
 
-use std::borrow::Cow;
-use std::cmp::{max, min};
-use std::iter::repeat;
-use std::ops::Range;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use alloc::string::String;
+use core::cmp::{max, min};
+use core::iter::repeat;
+use core::ops::Range;
 
 use crate::BidiClass::*;
 use crate::format_chars as chars;

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -13,7 +13,6 @@
 
 use core::cmp::max;
 use core::ops::Range;
-use matches::matches;
 use alloc::vec::Vec;
 
 use super::BidiClass::{self, *};
@@ -74,7 +73,7 @@ pub fn isolating_run_sequences(
 
         sequence.push(run);
 
-        if matches!(end_class, RLI | LRI | FSI) {
+        if let RLI | LRI | FSI = end_class {
             // Resume this sequence after the isolate.
             stack.push(sequence);
         } else {
@@ -114,7 +113,7 @@ pub fn isolating_run_sequences(
             };
 
             // Get the level of the next non-removed char after the runs.
-            let succ_level = if matches!(original_classes[end_of_seq - 1], RLI | LRI | FSI) {
+            let succ_level = if let RLI | LRI | FSI = original_classes[end_of_seq - 1] {
                 para_level
             } else {
                 match original_classes[end_of_seq..].iter().position(
@@ -164,7 +163,10 @@ fn level_runs(levels: &[Level], original_classes: &[BidiClass]) -> Vec<LevelRun>
 ///
 /// <http://www.unicode.org/reports/tr9/#X9>
 pub fn removed_by_x9(class: BidiClass) -> bool {
-    matches!(class, RLE | LRE | RLO | LRO | PDF | BN)
+    match class {
+        RLE | LRE | RLO | LRO | PDF | BN => true,
+        _ => false,
+    }
 }
 
 // For use as a predicate for `position` / `rposition`

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -11,9 +11,10 @@
 //!
 //! <http://www.unicode.org/reports/tr9/#Preparations_for_Implicit_Processing>
 
-use std::cmp::max;
-use std::ops::Range;
+use core::cmp::max;
+use core::ops::Range;
 use matches::matches;
+use alloc::vec::Vec;
 
 use super::BidiClass::{self, *};
 use super::level::Level;


### PR DESCRIPTION
Because of the matches crate, to actually be used on `no_std` targets, this requires either:
- https://github.com/SimonSapin/rust-std-candidates/pull/23
- That we bump the MSRV to 1.42.0
- That we change usage of the `matches!` macro

I opted for the last option here, but feel free to only take the first commit (which still compiles fine even though the subcrate isn't marked `no_std`, but downstream users will just get an error that they tried to link to std).