### PR TITLE
Bump version to 0.3.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"


### PR DESCRIPTION
Would release #57 and #58, neither contain breaking changes.