### PR TITLE
Fix `no_std`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,7 @@ jobs:
         with:
           command: test
           args: --features "serde"
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 
 #![no_std]
 // We need to link to std to make doc tests work on older Rust versions
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
Fixes a typo that I introduced in #58, which effectively disabled the entire crate when the default `std` feature was disabled.

Also, now we actually test the `no_std` support, so things like this shouldn't happen again.