### PR TITLE
Add pluggable data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,7 @@ jobs:
         with:
           command: test
           args: --no-default-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=hardcoded-data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ serde_test = ">=0.8, <2.0"
 [features]
 # Note: We don't actually use the `std` feature for anything other than making
 # doctests work. But it may come in handy in the future.
-default = ["std"]
+default = ["std", "hardcoded-data"]
+hardcoded-data = [] # Include hardcoded Bidi data
 std = []
 unstable = []  # travis-cargo needs it
 bench_it = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,7 @@ unstable = []  # travis-cargo needs it
 bench_it = []
 flame_it = ["flame", "flamer"]
 with_serde = ["serde"]  # DEPRECATED, please use `serde` feature, instead.
+
+[[test]]
+name = "conformance_tests"
+required-features = ["hardcoded-data"]

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -18,6 +18,16 @@ use core::char;
 
 use self::tables::bidi_class_table;
 use crate::BidiClass::*;
+use crate::BidiDataSource;
+
+/// Hardcoded Bidi data that ships with the unicode-bidi crate.
+pub struct HardcodedBidiData;
+
+impl BidiDataSource for HardcodedBidiData {
+    fn bidi_class(&self, c: char) -> BidiClass {
+        bsearch_range_value_table(c, bidi_class_table)
+    }
+}
 
 /// Find the `BidiClass` of a single char.
 pub fn bidi_class(c: char) -> BidiClass {

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -12,15 +12,20 @@
 mod tables;
 
 pub use self::tables::{BidiClass, UNICODE_VERSION};
-
+#[cfg(feature = "hardcoded-data")]
 use core::cmp::Ordering::{Equal, Less, Greater};
+#[cfg(feature = "hardcoded-data")]
 use core::char;
 
+#[cfg(feature = "hardcoded-data")]
 use self::tables::bidi_class_table;
 use crate::BidiClass::*;
+#[cfg(feature = "hardcoded-data")]
 use crate::BidiDataSource;
 
 /// Hardcoded Bidi data that ships with the unicode-bidi crate.
+///
+/// This can be enabled with the default `hardcoded-data` Cargo feature.
 #[cfg(feature = "hardcoded-data")]
 pub struct HardcodedBidiData;
 

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -21,8 +21,10 @@ use crate::BidiClass::*;
 use crate::BidiDataSource;
 
 /// Hardcoded Bidi data that ships with the unicode-bidi crate.
+#[cfg(feature = "hardcoded-data")]
 pub struct HardcodedBidiData;
 
+#[cfg(feature = "hardcoded-data")]
 impl BidiDataSource for HardcodedBidiData {
     fn bidi_class(&self, c: char) -> BidiClass {
         bsearch_range_value_table(c, bidi_class_table)
@@ -30,6 +32,7 @@ impl BidiDataSource for HardcodedBidiData {
 }
 
 /// Find the `BidiClass` of a single char.
+#[cfg(feature = "hardcoded-data")]
 pub fn bidi_class(c: char) -> BidiClass {
     bsearch_range_value_table(c, bidi_class_table)
 }
@@ -41,6 +44,7 @@ pub fn is_rtl(bidi_class: BidiClass) -> bool {
     }
 }
 
+#[cfg(feature = "hardcoded-data")]
 fn bsearch_range_value_table(c: char, r: &'static [(char, char, BidiClass)]) -> BidiClass {
     match r.binary_search_by(|&(lo, hi, _)| if lo <= c && c <= hi {
         Equal
@@ -59,7 +63,7 @@ fn bsearch_range_value_table(c: char, r: &'static [(char, char, BidiClass)]) -> 
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "hardcoded-data"))]
 mod tests {
     use super::*;
 

--- a/src/char_data/tables.rs
+++ b/src/char_data/tables.rs
@@ -42,6 +42,8 @@ pub enum BidiClass {
 }
 
 use self::BidiClass::*;
+
+#[cfg(feature = "hardcoded-data")]
 pub const bidi_class_table: &'static [(char, char, BidiClass)] = &[
     ('\u{0}', '\u{8}', BN), ('\u{9}', '\u{9}', S), ('\u{a}', '\u{a}', B), ('\u{b}', '\u{b}', S),
     ('\u{c}', '\u{c}', WS), ('\u{d}', '\u{d}', B), ('\u{e}', '\u{1b}', BN), ('\u{1c}', '\u{1e}', B),

--- a/src/char_data/tables.rs
+++ b/src/char_data/tables.rs
@@ -41,6 +41,7 @@ pub enum BidiClass {
     WS,
 }
 
+#[cfg(feature = "hardcoded-data")]
 use self::BidiClass::*;
 
 #[cfg(feature = "hardcoded-data")]

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Servo Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::BidiClass;
+
+/// This trait abstracts over a data source that is able to produce the Unicode Bidi class for a given
+/// character
+pub trait BidiDataSource {
+    fn bidi_class(&self, c: char) -> BidiClass;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! ## Example
 //!
 //! ```rust
+//! # #[cfg(feature = "hardcoded-data")] {
 //! use unicode_bidi::BidiInfo;
 //!
 //! // This example text is defined using `concat!` because some browsers
@@ -51,12 +52,14 @@
 //!   "ב",
 //!   "א",
 //! ]);
+//! # } // feature = "hardcoded-data"
 //! ```
 //!
 //! # Features
 //!
 //! - `std`: Enabled by default, but can be disabled to make `unicode_bidi`
 //!   `#![no_std]` + `alloc` compatible.
+//! - `hardcoded-data`: Enabled by default. Includes hardcoded Unicode bidi data and more convenient APIs.
 //! - `serde`: Adds [`serde::Serialize`] and [`serde::Deserialize`]
 //!   implementations to relevant types.
 //!
@@ -528,6 +531,7 @@ fn assign_levels_to_removed_chars(para_level: Level, classes: &[BidiClass], leve
 
 
 #[cfg(test)]
+#[cfg(feature = "hardcoded-data")]
 mod tests {
     use super::*;
 
@@ -599,6 +603,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hardcoded-data")]
     fn test_process_text() {
         let text = "abc123";
         assert_eq!(
@@ -718,6 +723,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hardcoded-data")]
     fn test_bidi_info_has_rtl() {
         // ASCII only
         assert_eq!(BidiInfo::new("123", None).has_rtl(), false);
@@ -741,6 +747,7 @@ mod tests {
         assert_eq!(BidiInfo::new("אבּג\n123", None).has_rtl(), true);
     }
 
+    #[cfg(feature = "hardcoded-data")]
     fn reorder_paras(text: &str) -> Vec<Cow<'_, str>> {
         let bidi_info = BidiInfo::new(text, None);
         bidi_info
@@ -751,6 +758,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hardcoded-data")]
     fn test_reorder_line() {
         // Bidi_Class: L L L B L L L B L L L
         assert_eq!(
@@ -848,6 +856,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hardcoded-data")]
     fn test_reordered_levels() {
 
         // BidiTest:946 (LRI PDI)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,13 +76,15 @@ pub mod format_chars;
 pub mod level;
 
 mod char_data;
+mod data_source;
 mod explicit;
 mod implicit;
 mod prepare;
 
-pub use crate::char_data::{BidiClass, bidi_class, UNICODE_VERSION};
+pub use crate::char_data::{BidiClass, HardcodedBidiData, bidi_class, UNICODE_VERSION};
 pub use crate::level::{Level, LTR_LEVEL, RTL_LEVEL};
 pub use crate::prepare::LevelRun;
+pub use crate::data_source::BidiDataSource;
 
 use alloc::borrow::Cow;
 use alloc::vec::Vec;

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(feature = "hardcoded-data")]
 use unicode_bidi::bidi_class;
 use unicode_bidi::{BidiInfo, format_chars, level, Level};
 
@@ -27,7 +26,6 @@ struct Fail {
 
 #[test]
 #[should_panic(expected = "314 test cases failed! (256433 passed)")]
-#[cfg(feature = "hardcoded-data")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 
@@ -142,7 +140,6 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 
 #[test]
 #[should_panic(expected = "14558 test cases failed! (77141 passed)")]
-#[cfg(feature = "hardcoded-data")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 
@@ -231,7 +228,6 @@ fn gen_base_level_for_characters_tests(idx: usize) -> Option<Level> {
     VALUES[idx]
 }
 
-
 fn get_sample_string_from_bidi_classes(class_names: &[&str]) -> String {
     class_names
         .iter()
@@ -269,7 +265,6 @@ fn gen_char_from_bidi_class(class_name: &str) -> char {
 }
 
 #[test]
-#[cfg(feature = "hardcoded-data")]
 fn test_gen_char_from_bidi_class() {
     use unicode_bidi::BidiClass::*;
     for &class in &[

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -7,7 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use unicode_bidi::{bidi_class, BidiInfo, format_chars, level, Level};
+#[cfg(feature = "hardcoded-data")]
+use unicode_bidi::bidi_class;
+use unicode_bidi::{BidiInfo, format_chars, level, Level};
 
 #[derive(Debug)]
 struct Fail {
@@ -25,6 +27,7 @@ struct Fail {
 
 #[test]
 #[should_panic(expected = "314 test cases failed! (256433 passed)")]
+#[cfg(feature = "hardcoded-data")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 
@@ -139,6 +142,7 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 
 #[test]
 #[should_panic(expected = "14558 test cases failed! (77141 passed)")]
+#[cfg(feature = "hardcoded-data")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 
@@ -265,6 +269,7 @@ fn gen_char_from_bidi_class(class_name: &str) -> char {
 }
 
 #[test]
+#[cfg(feature = "hardcoded-data")]
 fn test_gen_char_from_bidi_class() {
     use unicode_bidi::BidiClass::*;
     for &class in &[

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -186,6 +186,7 @@ pub enum BidiClass {
         file_.write("    " + cat + ",\n")
     file_.write("""}
 
+#[cfg(feature = "hardcoded-data")]
 use self::BidiClass::*;
 
 #[cfg(feature = "hardcoded-data")]

--- a/tools/generate.py
+++ b/tools/generate.py
@@ -66,7 +66,7 @@ def load_unicode_data():
         if is_surrogate(cp):
             continue
         if range_start >= 0:
-            for i in xrange(range_start, cp):
+            for i in range(range_start, cp):
                 udict[i] = data;
             range_start = -1;
         if data[1].endswith(", First>"):
@@ -187,6 +187,8 @@ pub enum BidiClass {
     file_.write("""}
 
 use self::BidiClass::*;
+
+#[cfg(feature = "hardcoded-data")]
 """)
 
     emit_table(


### PR DESCRIPTION
Adds a trait that makes the data pluggable, and defines a default `hardcoded-data` feature.

We shouldn't release this just yet, I'd like to also perform a Unicode 14 update.


cc @younies