### PR TITLE
Add missing platform for fmt CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
           command: test
           args: --no-default-features --features=hardcoded-data
   Fmt:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - "Test"
+      - "Fmt"
     steps:
       - name: Mark the job as successful
         run: exit 0


### PR DESCRIPTION
Eg: https://github.com/servo/unicode-bidi/actions/runs/2037210406