### PR TITLE
Make data_source public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,12 +73,12 @@ extern crate std;
 #[macro_use]
 extern crate alloc;
 
+pub mod data_source;
 pub mod deprecated;
 pub mod format_chars;
 pub mod level;
 
 mod char_data;
-mod data_source;
 mod explicit;
 mod implicit;
 mod prepare;


### PR DESCRIPTION
In order to implement data_source, we need to make `mod data_source` public.