### PR TITLE
Bump to 0.3.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"


### PR DESCRIPTION
The hardcoded data stuff doesn't actually include breaking changes since it's purely new APIs (though it may affect people running with `default-features = false` unfortunately), happy to make it 0.4 instead.