### PR TITLE
Fix W2 rule ordering; behavior of multibyte characters in W4

### DIFF
--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -22,7 +22,11 @@ use super::BidiDataSource;
 ///
 /// <http://www.unicode.org/reports/tr9/#Resolving_Weak_Types>
 #[cfg_attr(feature = "flame_it", flamer::flame)]
-pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [BidiClass]) {
+pub fn resolve_weak(
+    text: &str,
+    sequence: &IsolatingRunSequence,
+    processing_classes: &mut [BidiClass],
+) {
     // FIXME (#8): This function applies steps W1-W6 in a single pass.  This can produce
     // incorrect results in cases where a "later" rule changes the value of `prev_class` seen
     // by an "earlier" rule.  We should either split this into separate passes, or preserve
@@ -77,20 +81,30 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
 
             // <http://www.unicode.org/reports/tr9/#W4>
             ES | CS => {
-                let mut next_class = indices
-                    .clone()
-                    .map(|j| processing_classes[j])
-                    .find(not_removed_by_x9)
-                    .unwrap_or(sequence.eos);
-                if next_class == EN && last_strong_is_al {
-                    // Apply W2 to next_class. We know that last_strong_is_al
-                    // has no chance of changing on this character so we can still presume its value
-                    next_class = AN;
-                }
-                processing_classes[i] = match (prev_class, processing_classes[i], next_class) {
-                    (EN, ES, EN) | (EN, CS, EN) => EN,
-                    (AN, CS, AN) => AN,
-                    (_, _, _) => ON,
+                // see https://github.com/servo/unicode-bidi/issues/86
+                // We want to make sure we check the correct next character by skipping past the rest
+                // of this one
+                if let Some(ch) = text.get(i..).and_then(|s| s.chars().next()) {
+                    let mut next_class = indices
+                        .clone()
+                        .skip(ch.len_utf8() - 1)
+                        .map(|j| processing_classes[j])
+                        .find(not_removed_by_x9)
+                        .unwrap_or(sequence.eos);
+                    if next_class == EN && last_strong_is_al {
+                        // Apply W2 to next_class. We know that last_strong_is_al
+                        // has no chance of changing on this character so we can still presume its value
+                        next_class = AN;
+                    }
+                    processing_classes[i] = match (prev_class, processing_classes[i], next_class) {
+                        (EN, ES, EN) | (EN, CS, EN) => EN,
+                        (AN, CS, AN) => AN,
+                        (_, _, _) => ON,
+                    }
+                } else {
+                    // we're in the middle of a character, copy over work done for previous bytes
+                    // since it's going to be the same answer
+                    processing_classes[i] = prev_class;
                 }
             }
             // <http://www.unicode.org/reports/tr9/#W5>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ impl<'text> BidiInfo<'text> {
 
             let sequences = prepare::isolating_run_sequences(para.level, original_classes, levels);
             for sequence in &sequences {
-                implicit::resolve_weak(sequence, processing_classes);
+                implicit::resolve_weak(text, sequence, processing_classes);
                 implicit::resolve_neutral(
                     text,
                     data_source,

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "314 test cases failed! (256433 passed)")]
+#[should_panic(expected = "198 test cases failed! (256549 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 
@@ -138,7 +138,7 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 }
 
 #[test]
-#[should_panic(expected = "34 test cases failed! (91673 passed)")]
+#[should_panic(expected = "29 test cases failed! (91678 passed)")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "198 test cases failed! (256549 passed)")]
+#[should_panic(expected = "131 test cases failed! (256616 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 


### PR DESCRIPTION
Progress on #90

The multibyte thing was found whilst investigating https://github.com/servo/unicode-bidi/issues/86. It's not necessarily the best way to do it, but it does fix some tests, and it's probably the best path forward until we know what we're doing in https://github.com/servo/unicode-bidi/issues/86