### PR TITLE
Handle retaining explicit formatting characters + other fixes

### DIFF
--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -13,6 +13,7 @@ use crate::BidiClass;
 ///
 /// It represents the matching *normalized* opening bracket for a given bracket in a bracket pair,
 /// and whether or not that bracket is opening.
+#[derive(Debug, Copy, Clone)]
 pub struct BidiMatchedOpeningBracket {
     /// The corresponding opening bracket in this bracket pair, normalized
     ///

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -156,10 +156,14 @@ pub fn compute(
             _ => {
                 let last = stack.last();
                 levels[i] = last.level;
-                match last.status {
-                    OverrideStatus::RTL => processing_classes[i] = R,
-                    OverrideStatus::LTR => processing_classes[i] = L,
-                    _ => {}
+                // This condition is not in the spec, but I am pretty sure that is a spec bug
+                // https://github.com/unicode-org/properties/issues/71
+                if original_classes[i] != BN {
+                    match last.status {
+                        OverrideStatus::RTL => processing_classes[i] = R,
+                        OverrideStatus::LTR => processing_classes[i] = L,
+                        _ => {}
+                    }
                 }
             }
         }

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -134,13 +134,10 @@ pub fn compute(
             // <http://www.unicode.org/reports/tr9/#X7>
             PDF => {
                 if overflow_isolate_count > 0 {
-                    continue;
-                }
-                if overflow_embedding_count > 0 {
+                    // do nothing
+                } else if overflow_embedding_count > 0 {
                     overflow_embedding_count -= 1;
-                    continue;
-                }
-                if stack.last().status != OverrideStatus::Isolate && stack.vec.len() >= 2 {
+                } else if stack.last().status != OverrideStatus::Isolate && stack.vec.len() >= 2 {
                     stack.vec.pop();
                 }
                 // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -98,12 +98,12 @@ pub fn compute(
                 if !is_isolate {
                     // X9 +
                     // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                    // (PDF handled below)
                     processing_classes[i] = BN;
                 }
             }
 
             // <http://www.unicode.org/reports/tr9/#X6a>
-            // The BN is from <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
             PDI => {
                 if overflow_isolate_count > 0 {
                     overflow_isolate_count -= 1;
@@ -145,6 +145,7 @@ pub fn compute(
                 }
                 // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
                 levels[i] = stack.last().level;
+                // X9 part of retaining explicit formatting characters
                 processing_classes[i] = BN;
             }
 

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -56,7 +56,7 @@ pub fn compute(
                     _ => false,
                 };
                 if is_isolate {
-                    // Redundant due to "Retaining explicit formatting characters" step
+                    // Redundant due to "Retaining explicit formatting characters" step.
                     // levels[i] = last_level;
                     match stack.last().status {
                         OverrideStatus::RTL => processing_classes[i] = R,
@@ -142,11 +142,11 @@ pub fn compute(
                 }
                 // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
                 levels[i] = stack.last().level;
-                // X9 part of retaining explicit formatting characters
+                // X9 part of retaining explicit formatting characters.
                 processing_classes[i] = BN;
             }
 
-            // Nothing
+            // Nothing.
             // BN case moved down to X6, see <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
             B => {}
 
@@ -154,7 +154,7 @@ pub fn compute(
             _ => {
                 let last = stack.last();
                 levels[i] = last.level;
-                // This condition is not in the spec, but I am pretty sure that is a spec bug
+                // This condition is not in the spec, but I am pretty sure that is a spec bug.
                 // https://www.unicode.org/L2/L2023/23014-amd-to-uax9.pdf
                 if original_classes[i] != BN {
                     match last.status {

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -158,7 +158,7 @@ pub fn compute(
                 let last = stack.last();
                 levels[i] = last.level;
                 // This condition is not in the spec, but I am pretty sure that is a spec bug
-                // https://github.com/unicode-org/properties/issues/71
+                // https://www.unicode.org/L2/L2023/23014-amd-to-uax9.pdf
                 if original_classes[i] != BN {
                     match last.status {
                         OverrideStatus::RTL => processing_classes[i] = R,

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -128,8 +128,9 @@ pub fn resolve_weak(
                             .find(not_removed_by_x9)
                             .unwrap_or(sequence.eos);
                         if next_class == EN && last_strong_is_al {
-                            // Apply W2 to next_class. We know that last_strong_is_al.
-                            // Has no chance of changing on this character so we can still presume its value.
+                            // Apply W2 to next_class. We know that last_strong_is_al
+                            // has no chance of changing on this character so we can still assume its value
+                            // will be the same by the time we get to it.
                             next_class = AN;
                         }
                         processing_classes[i] =
@@ -165,7 +166,7 @@ pub fn resolve_weak(
                         }
                     } else {
                         // We're in the middle of a character, copy over work done for previous bytes
-                        // since it's going to be the same answer/
+                        // since it's going to be the same answer.
                         processing_classes[i] = processing_classes[i - 1];
                     }
                 }

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -117,7 +117,7 @@ pub fn resolve_weak(
                 // <http://www.unicode.org/reports/tr9/#W4>
                 // <http://www.unicode.org/reports/tr9/#W6>
                 ES | CS => {
-                    // See https://github.com/servo/unicode-bidi/issues/86
+                    // See https://github.com/servo/unicode-bidi/issues/86 for improving this.
                     // We want to make sure we check the correct next character by skipping past the rest
                     // of this one.
                     if let Some(ch) = text.get(i..).and_then(|s| s.chars().next()) {
@@ -145,6 +145,8 @@ pub fn resolve_weak(
                         // W6 + <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
                         // We have to do this before W5 gets its grubby hands on these characters and thinks
                         // they're part of an ET run.
+                        // We check for ON to ensure that we had hit the W6 branch above, since this `ES | CS` match
+                        // arm handles both W4 and W6.
                         if processing_classes[i] == ON {
                             for idx in sequence.iter_backwards_from(i, run_index) {
                                 let class = &mut processing_classes[idx];

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -142,8 +142,7 @@ pub fn resolve_weak(
                                 (_, _, _) => ON,
                             };
 
-                        // W6 +
-                        // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                        // W6 + <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
                         // We have to do this before W5 gets its grubby hands on these characters and thinks
                         // they're part of an ET run.
                         if processing_classes[i] == ON {

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -219,7 +219,9 @@ pub fn resolve_neutral<D: BidiDataSource>(
     // N0. Process bracket pairs.
 
     // > Identify the bracket pairs in the current isolating run sequence according to BD16.
-    let bracket_pairs = identify_bracket_pairs(text, data_source, sequence, original_classes);
+    // We use processing_classes, not original_classes, due to a spec bug I am investigating
+    // https://github.com/unicode-org/properties/issues/68
+    let bracket_pairs = identify_bracket_pairs(text, data_source, sequence, processing_classes);
 
     // > For each bracket-pair element in the list of pairs of text positions
     //

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -32,11 +32,11 @@ pub fn resolve_weak(
     // for rules that care about surrounding characters. To deal with them, we retain additional state
     // about previous character classes that may have since been changed by later rules.
 
-    // The previous class for the purposes of rule W4/W6, not tracking changes made after or during W4
+    // The previous class for the purposes of rule W4/W6, not tracking changes made after or during W4.
     let mut prev_w46_class = sequence.sos;
-    // The previous class for the purposes of rule W5
+    // The previous class for the purposes of rule W5.
     let mut prev_w5_class = sequence.sos;
-    // The previous class for the purposes of rule W1, not tracking changes from any other rules
+    // The previous class for the purposes of rule W1, not tracking changes from any other rules.
     let mut prev_w1_class = sequence.sos;
     let mut last_strong_is_al = false;
     let mut et_run_indices = Vec::new(); // for W5
@@ -46,14 +46,14 @@ pub fn resolve_weak(
         for i in &mut level_run.clone() {
             if processing_classes[i] == BN {
                 // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
-                // keeps track of bn runs for W5 in case we see an ET
+                // Keeps track of bn runs for W5 in case we see an ET.
                 bn_run_indices.push(i);
-                // BNs aren't real, skip over them
+                // BNs aren't real, skip over them.
                 continue;
             }
 
-            // Store the processing class of all rules before W2/W1
-            // used to keep track of the last strong character for W2. W3 is able to insert new strong
+            // Store the processing class of all rules before W2/W1.
+            // Used to keep track of the last strong character for W2. W3 is able to insert new strong
             // characters, so we don't want to be misled by it.
             let mut w2_processing_class = processing_classes[i];
 
@@ -65,7 +65,7 @@ pub fn resolve_weak(
                     RLI | LRI | FSI | PDI => ON,
                     _ => prev_w1_class,
                 };
-                // W1 occurs before W2, update this
+                // W1 occurs before W2, update this.
                 w2_processing_class = processing_classes[i];
             }
 
@@ -81,12 +81,12 @@ pub fn resolve_weak(
                         processing_classes[i] = AN;
                     }
                 }
-                // W3
+                // W3.
                 AL => processing_classes[i] = R,
                 _ => {}
             }
 
-            // update last_strong_is_al
+            // update last_strong_is_al.
             match w2_processing_class {
                 L | R => {
                     last_strong_is_al = false;
@@ -117,9 +117,9 @@ pub fn resolve_weak(
                 // <http://www.unicode.org/reports/tr9/#W4>
                 // <http://www.unicode.org/reports/tr9/#W6>
                 ES | CS => {
-                    // see https://github.com/servo/unicode-bidi/issues/86
+                    // See https://github.com/servo/unicode-bidi/issues/86
                     // We want to make sure we check the correct next character by skipping past the rest
-                    // of this one
+                    // of this one.
                     if let Some(ch) = text.get(i..).and_then(|s| s.chars().next()) {
                         let mut next_class = sequence
                             .iter_forwards_from(i + ch.len_utf8(), run_index)
@@ -128,8 +128,8 @@ pub fn resolve_weak(
                             .find(not_removed_by_x9)
                             .unwrap_or(sequence.eos);
                         if next_class == EN && last_strong_is_al {
-                            // Apply W2 to next_class. We know that last_strong_is_al
-                            // has no chance of changing on this character so we can still presume its value
+                            // Apply W2 to next_class. We know that last_strong_is_al.
+                            // Has no chance of changing on this character so we can still presume its value.
                             next_class = AN;
                         }
                         processing_classes[i] =
@@ -144,8 +144,8 @@ pub fn resolve_weak(
 
                         // W6 +
                         // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
-                        // we have to do this before W5 gets its grubby hands on these characters and thinks
-                        // they're part of an ET run
+                        // We have to do this before W5 gets its grubby hands on these characters and thinks
+                        // they're part of an ET run.
                         if processing_classes[i] == ON {
                             for idx in sequence.iter_backwards_from(i, run_index) {
                                 let class = &mut processing_classes[idx];
@@ -163,8 +163,8 @@ pub fn resolve_weak(
                             }
                         }
                     } else {
-                        // we're in the middle of a character, copy over work done for previous bytes
-                        // since it's going to be the same answer
+                        // We're in the middle of a character, copy over work done for previous bytes
+                        // since it's going to be the same answer/
                         processing_classes[i] = processing_classes[i - 1];
                     }
                 }
@@ -174,7 +174,7 @@ pub fn resolve_weak(
                         EN => processing_classes[i] = EN,
                         _ => {
                             // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
-                            // if there was a BN run before this, that's now a part of this ET run
+                            // If there was a BN run before this, that's now a part of this ET run.
                             et_run_indices.extend(&bn_run_indices);
 
                             // In case this is followed by an EN.
@@ -189,7 +189,7 @@ pub fn resolve_weak(
             //
 
             // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
-            // BN runs would have already continued the loop, clear them before we get to the next one
+            // BN runs would have already continued the loop, clear them before we get to the next one.
             bn_run_indices.clear();
 
             // W6 above only deals with separators, so it doesn't change anything W5 cares about,
@@ -208,12 +208,12 @@ pub fn resolve_weak(
             }
 
             // We stashed this before W4/5/6 could get their grubby hands on it, and it's not
-            // used in the W6 terminator code below so we can update it now
+            // used in the W6 terminator code below so we can update it now.
             prev_w46_class = class_before_w456;
         }
     }
     // Rerun this check in case we ended with a sequence of BNs (i.e., we'd never
-    // hit the end of the for loop above)
+    // hit the end of the for loop above).
     // W6. If we didn't find an adjacent EN, turn any ETs into ON instead.
     for j in &et_run_indices {
         processing_classes[*j] = ON;
@@ -235,7 +235,7 @@ pub fn resolve_weak(
                     last_strong_is_l = false;
                 }
                 // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
-                // already scanning past BN here
+                // Already scanning past BN here.
                 _ => {}
             }
         }
@@ -264,14 +264,13 @@ pub fn resolve_neutral<D: BidiDataSource>(
     // N0. Process bracket pairs.
 
     // > Identify the bracket pairs in the current isolating run sequence according to BD16.
-    // We use processing_classes, not original_classes, due to a spec bug I am investigating
-    // https://github.com/unicode-org/properties/issues/68
+    // We use processing_classes, not original_classes, due to BD14/BD15
     let bracket_pairs = identify_bracket_pairs(text, data_source, sequence, processing_classes);
 
     // > For each bracket-pair element in the list of pairs of text positions
     //
     // Note: Rust ranges are interpreted as [start..end), be careful using `pair` directly
-    // for indexing as it will include the opening bracket pair but not the closing one
+    // for indexing as it will include the opening bracket pair but not the closing one.
     for pair in bracket_pairs {
         #[cfg(feature = "std")]
         debug_assert!(
@@ -315,8 +314,8 @@ pub fn resolve_neutral<D: BidiDataSource>(
                 }
             }
 
-            // if we have found a character with the class of the embedding direction
-            // we can bail early
+            // If we have found a character with the class of the embedding direction
+            // we can bail early.
             if found_e {
                 break;
             }
@@ -327,9 +326,9 @@ pub fn resolve_neutral<D: BidiDataSource>(
             class_to_set = Some(e);
         // > Otherwise, if there is a strong type it must be opposite the embedding direction
         } else if found_not_e {
-            // Therefore, test for an established context with a preceding strong type by
-            // checking backwards before the opening paired bracket
-            // until the first strong type (L, R, or sos) is found.
+            // > Therefore, test for an established context with a preceding strong type by
+            // > checking backwards before the opening paired bracket
+            // > until the first strong type (L, R, or sos) is found.
             // (see note above about processing_classes and character boundaries)
             let mut previous_strong = sequence
                 .iter_backwards_from(pair.start, pair.start_run)
@@ -354,13 +353,12 @@ pub fn resolve_neutral<D: BidiDataSource>(
             // > Otherwise set the type for both brackets in the pair to the embedding direction.
             // > Either way it gets set to previous_strong
             //
-            // XXXManishearth perhaps the reason the spec writes these as two separate lines is
-            // because sos is supposed to be handled differently?
+            // Both branches amount to setting the type to the strong type.
             class_to_set = Some(previous_strong);
         }
 
         if let Some(class_to_set) = class_to_set {
-            // update all processing classes corresponding to the start and end elements, as requested.
+            // Update all processing classes corresponding to the start and end elements, as requested.
             // We should include all bytes of the character, not the first one.
             let end_len_utf8 = text[pair.end..].chars().next().unwrap().len_utf8();
             for class in &mut processing_classes[pair.start..pair.start + start_len_utf8] {
@@ -405,10 +403,8 @@ pub fn resolve_neutral<D: BidiDataSource>(
         // > Therefore, do not set the type for that bracket pair
     }
 
-    // N1 and N2
-    // indices of every byte in this isolating run sequence
-    // XXXManishearth Note for later: is it okay to iterate over every index here, since
-    // that includes char boundaries?
+    // N1 and N2.
+    // Indices of every byte in this isolating run sequence
     let mut indices = sequence.runs.iter().flat_map(Clone::clone);
     let mut prev_class = sequence.sos;
     while let Some(mut i) = indices.next() {
@@ -464,13 +460,13 @@ pub fn resolve_neutral<D: BidiDataSource>(
 }
 
 struct BracketPair {
-    /// The text-relative index of the opening bracket
+    /// The text-relative index of the opening bracket.
     start: usize,
-    /// The text-relative index of the closing bracket
+    /// The text-relative index of the closing bracket.
     end: usize,
-    /// The index of the run (in the run sequence) that the opening bracket is in
+    /// The index of the run (in the run sequence) that the opening bracket is in.
     start_run: usize,
-    /// The index of the run (in the run sequence) that the closing bracket is in
+    /// The index of the run (in the run sequence) that the closing bracket is in.
     end_run: usize,
 }
 /// 3.1.3 Identifying Bracket Pairs
@@ -503,11 +499,9 @@ fn identify_bracket_pairs<D: BidiDataSource>(
             return ret;
         };
 
-        // XXXManishearth perhaps try and coalesce this into one of the earlier
-        // full-string iterator runs, perhaps explicit::compute()
         for (i, ch) in slice.char_indices() {
             let actual_index = level_run.start + i;
-            // all paren characters are ON
+            // All paren characters are ON.
             // From BidiBrackets.txt:
             // > The Unicode property value stability policy guarantees that characters
             // > which have bpt=o or bpt=c also have bc=ON and Bidi_M=Y
@@ -517,30 +511,30 @@ fn identify_bracket_pairs<D: BidiDataSource>(
 
             if let Some(matched) = data_source.bidi_matched_opening_bracket(ch) {
                 if matched.is_open {
-                    // If an opening paired bracket is found ...
+                    // > If an opening paired bracket is found ...
 
-                    // ... and there is no room in the stack,
-                    // stop processing BD16 for the remainder of the isolating run sequence.
+                    // > ... and there is no room in the stack,
+                    // > stop processing BD16 for the remainder of the isolating run sequence.
                     if stack.len() >= 63 {
                         break;
                     }
-                    // ... push its Bidi_Paired_Bracket property value and its text position onto the stack
+                    // > ... push its Bidi_Paired_Bracket property value and its text position onto the stack
                     stack.push((matched.opening, actual_index, run_index))
                 } else {
-                    // If a closing paired bracket is found, do the following
+                    // > If a closing paired bracket is found, do the following
 
-                    // Declare a variable that holds a reference to the current stack element
-                    // and initialize it with the top element of the stack.
+                    // > Declare a variable that holds a reference to the current stack element
+                    // > and initialize it with the top element of the stack.
                     // AND
-                    // Else, if the current stack element is not at the bottom of the stack
+                    // > Else, if the current stack element is not at the bottom of the stack
                     for (stack_index, element) in stack.iter().enumerate().rev() {
-                        // Compare the closing paired bracket being inspected or its canonical
-                        // equivalent to the bracket in the current stack element.
+                        // > Compare the closing paired bracket being inspected or its canonical
+                        // > equivalent to the bracket in the current stack element.
                         if element.0 == matched.opening {
-                            // If the values match, meaning the two characters form a bracket pair, then
+                            // > If the values match, meaning the two characters form a bracket pair, then
 
-                            // Append the text position in the current stack element together with the
-                            // text position of the closing paired bracket to the list.
+                            // > Append the text position in the current stack element together with the
+                            // > text position of the closing paired bracket to the list.
                             let pair = BracketPair {
                                 start: element.1,
                                 end: actual_index,
@@ -549,7 +543,7 @@ fn identify_bracket_pairs<D: BidiDataSource>(
                             };
                             ret.push(pair);
 
-                            // Pop the stack through the current stack element inclusively.
+                            // > Pop the stack through the current stack element inclusively.
                             stack.truncate(stack_index);
                             break;
                         }
@@ -558,8 +552,8 @@ fn identify_bracket_pairs<D: BidiDataSource>(
             }
         }
     }
-    // Sort the list of pairs of text positions in ascending order based on
-    // the text position of the opening paired bracket.
+    // > Sort the list of pairs of text positions in ascending order based on
+    // > the text position of the opening paired bracket.
     ret.sort_by_key(|r| r.start);
     ret
 }

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -166,6 +166,13 @@ pub fn resolve_weak(
             }
         }
     }
+    // Rerun this check in case we ended with a sequence of BNs (i.e., we'd never
+    // hit the end of the for loop above)
+    // W6. If we didn't find an adjacent EN, turn any ETs into ON instead.
+    for j in &et_run_indices {
+        processing_classes[*j] = ON;
+    }
+    et_run_indices.clear();
 
     // W7. If the previous strong char was L, change EN to L.
     let mut last_strong_is_l = sequence.sos == L;
@@ -370,11 +377,9 @@ pub fn resolve_neutral<D: BidiDataSource>(
                 match indices.next() {
                     Some(j) => {
                         i = j;
-                        if removed_by_x9(processing_classes[i]) {
-                            continue;
-                        }
                         next_class = processing_classes[j];
-                        if is_NI(next_class) {
+                        // The BN is for <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                        if is_NI(next_class) || next_class == BN {
                             ni_run.push(i);
                         } else {
                             break;

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -38,6 +38,7 @@ pub fn resolve_weak(
     let mut prev_class = sequence.sos;
     let mut last_strong_is_al = false;
     let mut et_run_indices = Vec::new(); // for W5
+    let mut bn_run_indices = Vec::new(); // for W5 +  <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
 
     // Like sequence.runs.iter().flat_map(Clone::clone), but make indices itself clonable.
     fn id(x: LevelRun) -> LevelRun {
@@ -89,6 +90,7 @@ pub fn resolve_weak(
                         .clone()
                         .skip(ch.len_utf8() - 1)
                         .map(|j| processing_classes[j])
+                        // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
                         .find(not_removed_by_x9)
                         .unwrap_or(sequence.eos);
                     if next_class == EN && last_strong_is_al {
@@ -100,6 +102,25 @@ pub fn resolve_weak(
                         (EN, ES, EN) | (EN, CS, EN) => EN,
                         (AN, CS, AN) => AN,
                         (_, _, _) => ON,
+                    };
+
+                    // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                    // we have to do this before W5 gets its grubby hands on these characters and thinks
+                    // they're part of an ET run
+                    if processing_classes[i] == ON {
+                        for class in processing_classes[..i]
+                            .iter_mut()
+                            .rev()
+                            .take_while(|c| **c == BN)
+                        {
+                            *class = ON;
+                        }
+                        for class in processing_classes[(i + ch.len_utf8() - 1)..]
+                            .iter_mut()
+                            .take_while(|c| **c == BN)
+                        {
+                            *class = ON;
+                        }
                     }
                 } else {
                     // we're in the middle of a character, copy over work done for previous bytes
@@ -111,15 +132,29 @@ pub fn resolve_weak(
             ET => {
                 match prev_class {
                     EN => processing_classes[i] = EN,
-                    _ => et_run_indices.push(i), // In case this is followed by an EN.
+                    _ => {
+                        // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                        // if there was a BN run before this, that's now a part of this ET run
+                        et_run_indices.extend(&bn_run_indices);
+
+                        // In case this is followed by an EN.
+                        et_run_indices.push(i);
+                    }
                 }
             }
-            class => {
-                if removed_by_x9(class) {
-                    continue;
-                }
+            BN => {
+                // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                // keeps track of bn runs for W5 in case we see an ET
+                bn_run_indices.push(i);
+                // skips over BNs for W1
+                continue;
             }
+            _ => {}
         }
+
+        // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+        // BN runs would not exit the above loop
+        bn_run_indices.clear();
 
         prev_class = processing_classes[i];
         match w2_processing_class {
@@ -154,6 +189,8 @@ pub fn resolve_weak(
                 R | AL => {
                     last_strong_is_l = false;
                 }
+                // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+                // already scanning past BN here
                 _ => {}
             }
         }
@@ -287,6 +324,14 @@ pub fn resolve_neutral<D: BidiDataSource>(
             for class in &mut processing_classes[pair.end..pair.end + end_len_utf8] {
                 *class = class_to_set;
             }
+            // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+            for class in processing_classes[..pair.start]
+                .iter_mut()
+                .rev()
+                .take_while(|c| **c == BN)
+            {
+                *class = class_to_set;
+            }
             // > Any number of characters that had original bidirectional character type NSM prior to the application of
             // > W1 that immediately follow a paired bracket which changed to L or R under N0 should change to match the type of their preceding bracket.
 
@@ -294,7 +339,7 @@ pub fn resolve_neutral<D: BidiDataSource>(
             // about character boundaries. We do need to be careful to skip the full set of bytes for the parentheses characters.
             let nsm_start = pair.start + start_len_utf8;
             for (idx, class) in original_classes[nsm_start..].iter().enumerate() {
-                if *class == BidiClass::NSM {
+                if *class == BidiClass::NSM || processing_classes[nsm_start + idx] == BN {
                     processing_classes[nsm_start + idx] = class_to_set;
                 } else {
                     break;
@@ -302,7 +347,7 @@ pub fn resolve_neutral<D: BidiDataSource>(
             }
             let nsm_end = pair.end + end_len_utf8;
             for (idx, class) in original_classes[nsm_end..].iter().enumerate() {
-                if *class == BidiClass::NSM {
+                if *class == BidiClass::NSM || processing_classes[nsm_end + idx] == BN {
                     processing_classes[nsm_end + idx] = class_to_set;
                 } else {
                     break;
@@ -322,7 +367,8 @@ pub fn resolve_neutral<D: BidiDataSource>(
     while let Some(mut i) = indices.next() {
         // Process sequences of NI characters.
         let mut ni_run = Vec::new();
-        if is_NI(processing_classes[i]) {
+        // The BN is for <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+        if is_NI(processing_classes[i]) || processing_classes[i] == BN {
             // Consume a run of consecutive NI characters.
             ni_run.push(i);
             let mut next_class;
@@ -470,6 +516,7 @@ pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> L
             (false, R) | (true, L) | (true, EN) | (true, AN) => {
                 levels[i].raise(1).expect("Level number error")
             }
+            // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters> handled here
             (_, _) => {}
         }
         max_level = max(max_level, levels[i]);

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -105,8 +105,7 @@ pub fn resolve_weak(
                                 }
                                 *class = ON;
                             }
-                            for idx in sequence.iter_forwards_from(i + ch.len_utf8(), run_index)
-                            {
+                            for idx in sequence.iter_forwards_from(i + ch.len_utf8(), run_index) {
                                 let class = &mut processing_classes[idx];
                                 if *class != BN {
                                     break;
@@ -387,7 +386,6 @@ pub fn resolve_neutral<D: BidiDataSource>(
                     }
                 };
             }
-
             // N1-N2.
             //
             // <http://www.unicode.org/reports/tr9/#N1>

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -54,6 +54,11 @@ pub fn resolve_weak(
                     };
                     // W1 occurs before W2, update this
                     w2_processing_class = processing_classes[i];
+
+                    // W1 occurs before W5/W6, track changed class
+                    if processing_classes[i] == ET {
+                        et_run_indices.push(i);
+                    }
                 }
                 EN => {
                     if last_strong_is_al {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -142,6 +142,45 @@ impl IsolatingRunSequence {
             return 0..0;
         }
     }
+
+    /// Given a text-relative position `pos` and an index of the level run it is in,
+    /// produce an iterator of all characters after and pos (`pos..`) that are in this
+    /// run sequence
+    pub(crate) fn iter_forwards_from(
+        &self,
+        pos: usize,
+        level_run_index: usize,
+    ) -> impl Iterator<Item = usize> + '_ {
+        let runs = &self.runs[level_run_index..];
+
+        // Check that it is in range
+        // (we can't use contains() since we want an inclusive range)
+        #[cfg(feature = "std")]
+        debug_assert!(runs[0].start <= pos && pos <= runs[0].end);
+
+        (pos..runs[0].end).chain(runs[1..].iter().flat_map(Clone::clone))
+    }
+
+    /// Given a text-relative position `pos` and an index of the level run it is in,
+    /// produce an iterator of all characters before and excludingpos (`..pos`) that are in this
+    /// run sequence
+    pub(crate) fn iter_backwards_from(
+        &self,
+        pos: usize,
+        level_run_index: usize,
+    ) -> impl Iterator<Item = usize> + '_ {
+        let prev_runs = &self.runs[..level_run_index];
+        let current = &self.runs[level_run_index];
+
+        // Check that it is in range
+        // (we can't use contains() since we want an inclusive range)
+        #[cfg(feature = "std")]
+        debug_assert!(current.start <= pos && pos <= current.end);
+
+        (current.start..pos)
+            .rev()
+            .chain(prev_runs.iter().rev().flat_map(Clone::clone))
+    }
 }
 
 /// Finds the level runs in a paragraph.

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -89,12 +89,35 @@ pub fn isolating_run_sequences(
         .map(|sequence: Vec<LevelRun>| {
             assert!(!sequence.is_empty());
 
-            let start_of_seq = sequence[0].start;
-            let end_of_seq = sequence[sequence.len() - 1].end;
-            let seq_level = levels[start_of_seq];
+            let mut result = IsolatingRunSequence {
+                runs: sequence,
+                sos: L,
+                eos: L,
+            };
+
+            let start_of_seq = result.runs[0].start;
+            let runs_len = result.runs.len();
+            let end_of_seq = result.runs[runs_len - 1].end;
+
+            // > (not counting characters removed by X9)
+            let seq_level = result
+                .iter_forwards_from(start_of_seq, 0)
+                .filter(|i| not_removed_by_x9(&original_classes[*i]))
+                .map(|i| levels[i])
+                .next()
+                .unwrap_or(levels[start_of_seq]);
+
+            // XXXManishearth the spec talks of a start and end level,
+            // but for a given IRS the two should be equivalent, yes?
+            let end_level = result
+                .iter_backwards_from(end_of_seq, runs_len - 1)
+                .filter(|i| not_removed_by_x9(&original_classes[*i]))
+                .map(|i| levels[i])
+                .next()
+                .unwrap_or(levels[end_of_seq - 1]);
 
             #[cfg(test)]
-            for run in sequence.clone() {
+            for run in result.runs.clone() {
                 for idx in run {
                     if not_removed_by_x9(&original_classes[idx]) {
                         assert_eq!(seq_level, levels[idx]);
@@ -111,8 +134,19 @@ pub fn isolating_run_sequences(
                 None => para_level,
             };
 
+            // Get the last non-removed character to check if it is an isolate initiator
+            // The spec calls for an unmatched one, but matched isolate initiators
+            // will never be at the end of a level run (otherwise there would be more to the run).
+            // We unwrap_or(BN) because BN marks removed classes and it won't matter for the check
+            let last_non_removed = original_classes[..end_of_seq]
+                .iter()
+                .copied()
+                .rev()
+                .find(not_removed_by_x9)
+                .unwrap_or(BN);
+
             // Get the level of the next non-removed char after the runs.
-            let succ_level = if let RLI | LRI | FSI = original_classes[end_of_seq - 1] {
+            let succ_level = if let RLI | LRI | FSI = last_non_removed {
                 para_level
             } else {
                 match original_classes[end_of_seq..]
@@ -124,16 +158,23 @@ pub fn isolating_run_sequences(
                 }
             };
 
-            IsolatingRunSequence {
-                runs: sequence,
-                sos: max(seq_level, pred_level).bidi_class(),
-                eos: max(seq_level, succ_level).bidi_class(),
-            }
+            result.sos = max(seq_level, pred_level).bidi_class();
+            result.eos = max(end_level, succ_level).bidi_class();
+            result
         })
         .collect()
 }
 
 impl IsolatingRunSequence {
+    /// Returns the full range of text represented by this isolating run sequence
+    pub(crate) fn text_range(&self) -> Range<usize> {
+        if let (Some(start), Some(end)) = (self.runs.first(), self.runs.last()) {
+            start.start..end.end
+        } else {
+            return 0..0;
+        }
+    }
+
     /// Given a text-relative position `pos` and an index of the level run it is in,
     /// produce an iterator of all characters after and pos (`pos..`) that are in this
     /// run sequence

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -134,15 +134,6 @@ pub fn isolating_run_sequences(
 }
 
 impl IsolatingRunSequence {
-    /// Returns the full range of text represented by this isolating run sequence
-    pub(crate) fn text_range(&self) -> Range<usize> {
-        if let (Some(start), Some(end)) = (self.runs.first(), self.runs.last()) {
-            start.start..end.end
-        } else {
-            return 0..0;
-        }
-    }
-
     /// Given a text-relative position `pos` and an index of the level run it is in,
     /// produce an iterator of all characters after and pos (`pos..`) that are in this
     /// run sequence

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -134,10 +134,10 @@ pub fn isolating_run_sequences(
                 None => para_level,
             };
 
-            // Get the last non-removed character to check if it is an isolate initiator
+            // Get the last non-removed character to check if it is an isolate initiator.
             // The spec calls for an unmatched one, but matched isolate initiators
             // will never be at the end of a level run (otherwise there would be more to the run).
-            // We unwrap_or(BN) because BN marks removed classes and it won't matter for the check
+            // We unwrap_or(BN) because BN marks removed classes and it won't matter for the check.
             let last_non_removed = original_classes[..end_of_seq]
                 .iter()
                 .copied()

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,6 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "1 test cases failed! (256746 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -138,7 +138,6 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 }
 
 #[test]
-#[should_panic(expected = "2 test cases failed! (91705 passed)")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "37 test cases failed! (256710 passed)")]
+#[should_panic(expected = "9 test cases failed! (256738 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "3 test cases failed! (256744 passed)")]
+#[should_panic(expected = "1 test cases failed! (256746 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -138,7 +138,7 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 }
 
 #[test]
-#[should_panic(expected = "13 test cases failed! (91694 passed)")]
+#[should_panic(expected = "2 test cases failed! (91705 passed)")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "121 test cases failed! (256626 passed)")]
+#[should_panic(expected = "37 test cases failed! (256710 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -138,7 +138,7 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 }
 
 #[test]
-#[should_panic(expected = "19 test cases failed! (91688 passed)")]
+#[should_panic(expected = "13 test cases failed! (91694 passed)")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "9 test cases failed! (256738 passed)")]
+#[should_panic(expected = "3 test cases failed! (256744 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "131 test cases failed! (256616 passed)")]
+#[should_panic(expected = "125 test cases failed! (256622 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 
@@ -138,7 +138,7 @@ fn gen_base_levels_for_base_tests(bitset: u8) -> Vec<Option<Level>> {
 }
 
 #[test]
-#[should_panic(expected = "29 test cases failed! (91678 passed)")]
+#[should_panic(expected = "19 test cases failed! (91688 passed)")]
 fn test_character_conformance() {
     let test_data = include_str!("data/BidiCharacterTest.txt");
 

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -25,7 +25,7 @@ struct Fail {
 }
 
 #[test]
-#[should_panic(expected = "125 test cases failed! (256622 passed)")]
+#[should_panic(expected = "121 test cases failed! (256626 passed)")]
 fn test_basic_conformance() {
     let test_data = include_str!("data/BidiTest.txt");
 


### PR DESCRIPTION
Built on top of https://github.com/servo/unicode-bidi/pull/91. PR starts at "Add all fixups for retaining explicits".

Fixes #89 by doing the implementation hacks specified in section 5.2 [Retaining BNs and Explicit Formatting Characters](https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters).

This fixes all of the character tests! (fixes #90). <s>We still have to fix some of the "basic" tests, which are unfortunately not as nicely labeled as the character tests.</s> This also fixes the basic tests (fixes https://github.com/servo/unicode-bidi/issues/8 )

This got mixed in with a bunch of other fixes since a lot of the code is nearby, a bunch of them fix things from N0. The main Big Fix in here besides the one around retaining explicit formatting is that the code now _always_ handles lookahead/lookbehind by iterating within the run sequence only.

All in all, this PR contains:
 - Fixes for [Retaining BNs and Explicit Formatting Characters](https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters) (#89)
 - A fix for a spec bug in BD16
 - A typo/indexing fix from my work in #85 (oops)
 - A sequence of changes so that all lookahead/lookbehind works within the run sequence only.
 - A bunch of rule ordering fixes in the W rules (#8)