### PR TITLE
Add Level::from_slice_unchecked()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@
 //!
 //! [tr9]: <http://www.unicode.org/reports/tr9/>
 
-#![forbid(unsafe_code)]
 #![no_std]
 // We need to link to std to make doc tests work on older Rust versions
 #[cfg(feature = "std")]


### PR DESCRIPTION
To be able to use this over FFI I'd like to make this more explicitly transparent over u8.

I could also just mark it as transparent and let callers implement this, but I think offering it as an API is safer.