### PR TITLE
Run reordering conformance tests, more docs for reordering, fix bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,7 +682,7 @@ impl<'text> BidiInfo<'text> {
             // Look for the start of a sequence of consecutive runs of max_level or higher.
             let mut seq_start = 0;
             while seq_start < run_count {
-                if self.levels[runs[seq_start].start] < max_level {
+                if levels[runs[seq_start].start] < max_level {
                     seq_start += 1;
                     continue;
                 }
@@ -690,7 +690,7 @@ impl<'text> BidiInfo<'text> {
                 // Found the start of a sequence. Now find the end.
                 let mut seq_end = seq_start + 1;
                 while seq_end < run_count {
-                    if self.levels[runs[seq_end].start] < max_level {
+                    if levels[runs[seq_end].start] < max_level {
                         break;
                     }
                     seq_end += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1027,7 +1027,7 @@ mod tests {
         // Testing for RLE Character
         assert_eq!(
             reorder_paras("\u{202B}abc אבג\u{202C}"),
-            vec!["\u{202B}\u{202C}גבא abc"]
+            vec!["\u{202b}גבא abc\u{202c}"]
         );
 
         // Testing neutral characters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -674,10 +674,6 @@ impl<'text> BidiInfo<'text> {
         min_level = min_level.new_lowest_ge_rtl().expect("Level error");
         // This loop goes through contiguous chunks of level runs that have a level
         // ≥ max_level and reverses their contents, reducing max_level by 1 each time.
-        //
-        // It can do this check with the original levels instead of checking reorderings because all
-        // prior reorderings will have been for contiguous chunks of levels >> max, which will
-        // be a subset of these chunks anyway.
         while max_level >= min_level {
             // Look for the start of a sequence of consecutive runs of max_level or higher.
             let mut seq_start = 0;


### PR DESCRIPTION
Fixes https://github.com/servo/unicode-bidi/issues/88

We now run the reordering part of the conformance tests. Good news: we already passed them all for `reorder_visual()`!. There was a small bug when it came to `visual_runs()` which took a bit of sleuthing but was easy to fix.