### PR TITLE
Pin serde dep for MSRV build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           profile: minimal
+      - name: Potentially pin serde dep for MSRV check
+        if: ${{ matrix.rust == 1.36.0 }}
+        run: cargo update -p serde --precise 1.0.156
       - uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
Fixes broken CI: syn 2.0 has a new MSRV

(We only depend on these for tests, but still)