### PR TITLE
UTF-16 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ name = "unicode_bidi"
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.4", optional = true }
 serde = { version = ">=0.8, <2.0", default-features = false, optional = true, features = ["derive"] }
-sealed = "0.5"
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ name = "unicode_bidi"
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.4", optional = true }
 serde = { version = ">=0.8, <2.0", default-features = false, optional = true, features = ["derive"] }
+sealed = "0.5"
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -15,7 +15,8 @@ extern crate unicode_bidi;
 
 use test::Bencher;
 
-use unicode_bidi::{BidiInfo, BidiInfoU16};
+use unicode_bidi::BidiInfo;
+use unicode_bidi::utf16::BidiInfo as BidiInfoU16;
 
 fn to_utf16(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -15,7 +15,11 @@ extern crate unicode_bidi;
 
 use test::Bencher;
 
-use unicode_bidi::BidiInfo;
+use unicode_bidi::{BidiInfo, BidiInfoU16};
+
+fn to_utf16(s: &str) -> Vec<u16> {
+    s.encode_utf16().collect()
+}
 
 const LTR_TEXTS: &[&str] = &["abc\ndef\nghi", "abc 123\ndef 456\nghi 789"];
 
@@ -29,9 +33,29 @@ fn bench_bidi_info_new(b: &mut Bencher, texts: &[&str]) {
     }
 }
 
+fn bench_bidi_info_new_u16(b: &mut Bencher, texts: &Vec<Vec<u16>>) {
+    for text in texts {
+        b.iter(|| {
+            BidiInfoU16::new(&text, None);
+        });
+    }
+}
+
 fn bench_reorder_line(b: &mut Bencher, texts: &[&str]) {
     for text in texts {
         let bidi_info = BidiInfo::new(text, None);
+        b.iter(|| {
+            for para in &bidi_info.paragraphs {
+                let line = para.range.clone();
+                bidi_info.reorder_line(para, line);
+            }
+        });
+    }
+}
+
+fn bench_reorder_line_u16(b: &mut Bencher, texts: &Vec<Vec<u16>>) {
+    for text in texts {
+        let bidi_info = BidiInfoU16::new(text, None);
         b.iter(|| {
             for para in &bidi_info.paragraphs {
                 let line = para.range.clone();
@@ -59,4 +83,28 @@ fn bench_3_reorder_line_for_ltr_texts(b: &mut Bencher) {
 #[bench]
 fn bench_4_reorder_line_for_bidi_texts(b: &mut Bencher) {
     bench_reorder_line(b, BIDI_TEXTS);
+}
+
+#[bench]
+fn bench_5_bidi_info_new_for_ltr_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = LTR_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_bidi_info_new_u16(b, &texts_u16);
+}
+
+#[bench]
+fn bench_6_bidi_info_new_for_bidi_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = BIDI_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_bidi_info_new_u16(b, &texts_u16);
+}
+
+#[bench]
+fn bench_7_reorder_line_for_ltr_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = LTR_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_reorder_line_u16(b, &texts_u16);
+}
+
+#[bench]
+fn bench_8_reorder_line_for_bidi_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = BIDI_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_reorder_line_u16(b, &texts_u16);
 }

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -15,8 +15,8 @@ extern crate unicode_bidi;
 
 use test::Bencher;
 
-use unicode_bidi::BidiInfo;
 use unicode_bidi::utf16::BidiInfo as BidiInfoU16;
+use unicode_bidi::BidiInfo;
 
 fn to_utf16(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()

--- a/benches/udhr.rs
+++ b/benches/udhr.rs
@@ -15,7 +15,8 @@ extern crate unicode_bidi;
 
 use test::Bencher;
 
-use unicode_bidi::{BidiInfo, BidiInfoU16};
+use unicode_bidi::BidiInfo;
+use unicode_bidi::utf16::BidiInfo as BidiInfoU16;
 
 fn to_utf16(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()

--- a/benches/udhr.rs
+++ b/benches/udhr.rs
@@ -15,7 +15,11 @@ extern crate unicode_bidi;
 
 use test::Bencher;
 
-use unicode_bidi::BidiInfo;
+use unicode_bidi::{BidiInfo, BidiInfoU16};
+
+fn to_utf16(s: &str) -> Vec<u16> {
+    s.encode_utf16().collect()
+}
 
 const LTR_TEXTS: &[&str] = &[
     include_str!("../data/udhr/ltr/udhr_acu_1.txt"),
@@ -55,9 +59,29 @@ fn bench_bidi_info_new(b: &mut Bencher, texts: &[&str]) {
     }
 }
 
+fn bench_bidi_info_new_u16(b: &mut Bencher, texts: &Vec<Vec<u16>>) {
+    for text in texts {
+        b.iter(|| {
+            BidiInfoU16::new(&text, None);
+        });
+    }
+}
+
 fn bench_reorder_line(b: &mut Bencher, texts: &[&str]) {
     for text in texts {
         let bidi_info = BidiInfo::new(text, None);
+        b.iter(|| {
+            for para in &bidi_info.paragraphs {
+                let line = para.range.clone();
+                bidi_info.reorder_line(para, line);
+            }
+        });
+    }
+}
+
+fn bench_reorder_line_u16(b: &mut Bencher, texts: &Vec<Vec<u16>>) {
+    for text in texts {
+        let bidi_info = BidiInfoU16::new(text, None);
         b.iter(|| {
             for para in &bidi_info.paragraphs {
                 let line = para.range.clone();
@@ -85,4 +109,28 @@ fn bench_3_reorder_line_for_ltr_texts(b: &mut Bencher) {
 #[bench]
 fn bench_4_reorder_line_for_bidi_texts(b: &mut Bencher) {
     bench_reorder_line(b, BIDI_TEXTS);
+}
+
+#[bench]
+fn bench_5_bidi_info_new_for_ltr_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = LTR_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_bidi_info_new_u16(b, &texts_u16);
+}
+
+#[bench]
+fn bench_6_bidi_info_new_for_bidi_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = BIDI_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_bidi_info_new_u16(b, &texts_u16);
+}
+
+#[bench]
+fn bench_7_reorder_line_for_ltr_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = LTR_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_reorder_line_u16(b, &texts_u16);
+}
+
+#[bench]
+fn bench_8_reorder_line_for_bidi_texts_u16(b: &mut Bencher) {
+    let texts_u16: Vec<_> = BIDI_TEXTS.iter().map(|t| to_utf16(t)).collect();
+    bench_reorder_line_u16(b, &texts_u16);
 }

--- a/benches/udhr.rs
+++ b/benches/udhr.rs
@@ -15,8 +15,8 @@ extern crate unicode_bidi;
 
 use test::Bencher;
 
-use unicode_bidi::BidiInfo;
 use unicode_bidi::utf16::BidiInfo as BidiInfoU16;
+use unicode_bidi::BidiInfo;
 
 fn to_utf16(s: &str) -> Vec<u16> {
     s.encode_utf16().collect()

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -31,9 +31,7 @@ pub fn compute<'a, T: TextSource<'a> + ?Sized>(
     original_classes: &[BidiClass],
     levels: &mut [Level],
     processing_classes: &mut [BidiClass],
-) where
-    <T as TextSource<'a>>::IndexLenIter: Iterator<Item = (usize, usize)>,
-{
+) {
     assert_eq!(text.len(), original_classes.len());
 
     // <http://www.unicode.org/reports/tr9/#X1>

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -18,19 +18,22 @@ use super::char_data::{
     BidiClass::{self, *},
 };
 use super::level::Level;
+use super::TextSource;
 
 /// Compute explicit embedding levels for one paragraph of text (X1-X8).
 ///
 /// `processing_classes[i]` must contain the `BidiClass` of the char at byte index `i`,
 /// for each char in `text`.
 #[cfg_attr(feature = "flame_it", flamer::flame)]
-pub fn compute(
-    text: &str,
+pub fn compute<'a, T: TextSource<'a> + ?Sized>(
+    text: &'a T,
     para_level: Level,
     original_classes: &[BidiClass],
     levels: &mut [Level],
     processing_classes: &mut [BidiClass],
-) {
+) where
+    <T as TextSource<'a>>::IndexLenIter: Iterator<Item = (usize, usize)>,
+{
     assert_eq!(text.len(), original_classes.len());
 
     // <http://www.unicode.org/reports/tr9/#X1>
@@ -41,7 +44,7 @@ pub fn compute(
     let mut overflow_embedding_count = 0u32;
     let mut valid_isolate_count = 0u32;
 
-    for (i, c) in text.char_indices() {
+    for (i, len) in text.indices_lengths() {
         match original_classes[i] {
             // Rules X2-X5c
             RLE | LRE | RLO | LRO | RLI | LRI | FSI => {
@@ -167,7 +170,7 @@ pub fn compute(
         }
 
         // Handle multi-byte characters.
-        for j in 1..c.len_utf8() {
+        for j in 1..len {
             levels[i + j] = levels[i];
             processing_classes[i + j] = processing_classes[i];
         }

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -255,10 +255,7 @@ pub fn resolve_neutral<'a, D: BidiDataSource, T: TextSource<'a> + ?Sized>(
     levels: &[Level],
     original_classes: &[BidiClass],
     processing_classes: &mut [BidiClass],
-) where
-    <T as TextSource<'a>>::CharIndexIter: Iterator<Item = (usize, char)>,
-    <T as TextSource<'a>>::CharIter: Iterator<Item = char>,
-{
+) {
     // e = embedding direction
     let e: BidiClass = levels[sequence.runs[0].start].bidi_class();
     let not_e = if e == BidiClass::L {
@@ -487,10 +484,7 @@ fn identify_bracket_pairs<'a, T: TextSource<'a> + ?Sized, D: BidiDataSource>(
     data_source: &D,
     run_sequence: &IsolatingRunSequence,
     original_classes: &[BidiClass],
-) -> Vec<BracketPair>
-where
-    <T as TextSource<'a>>::CharIndexIter: Iterator<Item = (usize, char)>,
-{
+) -> Vec<BracketPair> {
     let mut ret = vec![];
     let mut stack = vec![];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,20 +76,17 @@ pub mod data_source;
 pub mod deprecated;
 pub mod format_chars;
 pub mod level;
+pub mod utf16;
 
 mod char_data;
 mod explicit;
 mod implicit;
 mod prepare;
-mod utf16;
 
 pub use crate::char_data::{BidiClass, UNICODE_VERSION};
 pub use crate::data_source::BidiDataSource;
 pub use crate::level::{Level, LTR_LEVEL, RTL_LEVEL};
 pub use crate::prepare::LevelRun;
-pub use crate::utf16::{
-    BidiInfo as BidiInfoU16, InitialInfo as InitialInfoU16, Paragraph as ParagraphU16,
-};
 
 #[cfg(feature = "hardcoded-data")]
 pub use crate::char_data::{bidi_class, HardcodedBidiData};
@@ -1094,6 +1091,10 @@ fn to_utf16(s: &str) -> Vec<u16> {
 #[cfg(feature = "hardcoded-data")]
 mod tests {
     use super::*;
+
+    use utf16::{
+        BidiInfo as BidiInfoU16, InitialInfo as InitialInfoU16, Paragraph as ParagraphU16
+    };
 
     #[test]
     fn test_utf16_text_source() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,11 @@ pub trait TextSource<'text> {
     #[doc(hidden)]
     fn char_at(&self, index: usize) -> Option<(char, usize)>;
 
+    /// Return a subrange of the text, indexed by code units.
+    /// (We don't implement all of the Index trait, just the minimum we use.)
+    #[doc(hidden)]
+    fn subrange(&self, range: Range<usize>) -> &Self;
+
     /// An iterator over the text returning Unicode characters,
     /// REPLACEMENT_CHAR for invalid code units.
     #[doc(hidden)]
@@ -892,6 +897,10 @@ impl<'text> TextSource<'text> for str {
             }
         }
         None
+    }
+    #[inline]
+    fn subrange(&self, range: Range<usize>) -> &Self {
+        &(self as &str)[range]
     }
     #[inline]
     fn chars(&'text self) -> Self::CharIter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,16 +101,15 @@ use core::cmp;
 use core::iter::repeat;
 use core::ops::Range;
 use core::str::CharIndices;
-use sealed::sealed;
 
 use crate::format_chars as chars;
 use crate::BidiClass::*;
 
 /// Trait that abstracts over a text source for use by the bidi algorithms.
 /// We implement this for str (UTF-8) and for [u16] (UTF-16, native-endian).
-/// (Internal unicode-bidi use; unstable for implementation or direct use.)
-#[sealed]
-pub trait TextSource<'text> {
+/// (For internal unicode-bidi use; API may be unstable.)
+/// This trait is sealed and cannot be implemented for types outside this crate.
+pub trait TextSource<'text>: private::Sealed {
     type CharIter;
     type CharIndexIter;
     type IndexLenIter;
@@ -150,6 +149,14 @@ pub trait TextSource<'text> {
     /// Number of code units the given character uses.
     #[doc(hidden)]
     fn char_len(ch: char) -> usize;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    // Implement for str and [u16] only.
+    impl Sealed for str {}
+    impl Sealed for [u16] {}
 }
 
 #[derive(PartialEq, Debug)]
@@ -1010,7 +1017,6 @@ fn assign_levels_to_removed_chars(para_level: Level, classes: &[BidiClass], leve
 }
 
 /// Implementation of TextSource for UTF-8 text (a string slice).
-#[sealed]
 impl<'text> TextSource<'text> for str {
     type CharIter = core::str::Chars<'text>;
     type CharIndexIter = core::str::CharIndices<'text>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::char_data::{bidi_class, HardcodedBidiData};
 use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::char;
 use core::cmp;
 use core::iter::repeat;
 use core::ops::Range;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn test_initial_text_info() {
-        let tests = [
+        let tests = vec![
             (
                 // text
                 "a1",
@@ -1206,7 +1206,7 @@ mod tests {
                 ],
             ),
             (
-                &format!("{}א{}a", chars::FSI, chars::PDI),
+                "\u{2068}א\u{2069}a", // U+2068 FSI, U+2069 PDI
                 vec![RLI, RLI, RLI, R, R, PDI, PDI, PDI, L],
                 vec![ParagraphInfo {
                     range: 0..9,
@@ -1244,7 +1244,7 @@ mod tests {
     #[test]
     #[cfg(feature = "hardcoded-data")]
     fn test_process_text() {
-        let tests = [
+        let tests = vec![
             (
                 // text
                 "abc123",
@@ -1422,7 +1422,7 @@ mod tests {
     #[test]
     #[cfg(feature = "hardcoded-data")]
     fn test_bidi_info_has_rtl() {
-        let tests = [
+        let tests = vec![
             // ASCII only
             ("123", None, false),
             ("123", Some(LTR_LEVEL), false),
@@ -1473,7 +1473,7 @@ mod tests {
     #[test]
     #[cfg(feature = "hardcoded-data")]
     fn test_reorder_line() {
-        let tests = [
+        let tests = vec![
             // Bidi_Class: L L L B L L L B L L L
             ("abc\ndef\nghi", vec!["abc\n", "def\n", "ghi"]),
             // Bidi_Class: L L EN B L L EN B L L EN
@@ -1565,7 +1565,7 @@ mod tests {
     #[test]
     #[cfg(feature = "hardcoded-data")]
     fn test_reordered_levels() {
-        let tests = [
+        let tests = vec![
             // BidiTest:946 (LRI PDI)
             (
                 "\u{2067}\u{2069}",
@@ -1590,7 +1590,7 @@ mod tests {
             assert_eq!(reordered_levels_per_char_for_paras_u16(text), t.2);
         }
 
-        let tests = [
+        let tests = vec![
             // BidiTest:291284 (AN RLI PDF R)
             (
                 "\u{0605}\u{2067}\u{202C}\u{0590}",
@@ -1691,7 +1691,7 @@ mod tests {
         let bidi_info = BidiInfoU16::new(empty, Option::from(RTL_LEVEL));
         assert_eq!(bidi_info.paragraphs.len(), 0);
 
-        let tests = [
+        let tests = vec![
             // The paragraph separator will take the value of the default direction
             // which is left to right.
             ("\n", None, Direction::Ltr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,15 +878,9 @@ fn compute_bidi_info_for_para<'a, D: BidiDataSource, T: TextSource<'a> + ?Sized>
 /// in the paragraph. The returned vector includes code units that are not included
 /// in the `line`, but will not adjust them.
 ///
-/// This runs [Rule L1], you can run
-/// [Rule L2] by calling [`reorder_visual()`].
-/// If doing so, you may prefer to use [`reordered_levels_per_char()`] instead
-/// to avoid non-character indices.
-///
-/// For an all-in-one reordering solution, consider using [`Self::reorder_visual()`].
+/// This runs [Rule L1]
 ///
 /// [Rule L1]: https://www.unicode.org/reports/tr9/#L1
-/// [Rule L2]: https://www.unicode.org/reports/tr9/#L2
 fn reorder_levels<'a, T: TextSource<'a> + ?Sized>(
     line_classes: &[BidiClass],
     line_levels: &mut [Level],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,7 +1088,7 @@ mod tests {
     use super::*;
 
     use utf16::{
-        BidiInfo as BidiInfoU16, InitialInfo as InitialInfoU16, Paragraph as ParagraphU16
+        BidiInfo as BidiInfoU16, InitialInfo as InitialInfoU16, Paragraph as ParagraphU16,
     };
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -836,6 +836,7 @@ fn compute_bidi_info_for_para<'a, D: BidiDataSource, T: TextSource<'a> + ?Sized>
     processing_classes: &mut [BidiClass],
     levels: &mut Vec<Level>,
 ) where
+    <T as TextSource<'a>>::CharIndexIter: Iterator<Item = (usize, char)>,
     <T as TextSource<'a>>::CharIter: Iterator<Item = char>,
     <T as TextSource<'a>>::IndexLenIter: Iterator<Item = (usize, usize)>,
 {

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -10,6 +10,7 @@
 use super::__seal_text_source;
 use super::TextSource;
 
+use core::ops::Range;
 use sealed::sealed;
 
 /// Implementation of TextSource for UTF-16 text in a [u16] array.
@@ -69,6 +70,10 @@ impl<'text> TextSource<'text> for [u16] {
         // Return REPLACEMENT_CHARACTER (not None), to continue processing the following text
         // and keep indexing correct.
         Some((char::REPLACEMENT_CHARACTER, 1))
+    }
+    #[inline]
+    fn subrange(&self, range: Range<usize>) -> &Self {
+        &(self as &[u16])[range]
     }
     #[inline]
     fn chars(&'text self) -> Self::CharIter {

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -8,12 +8,10 @@
 // except according to those terms.
 
 use super::TextSource;
-use super::__seal_text_source;
 
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::ops::Range;
-use sealed::sealed;
 
 use crate::{
     compute_bidi_info_for_para, compute_initial_info, level, para_direction, reorder_levels,
@@ -412,7 +410,6 @@ fn is_low_surrogate(code: u16) -> bool {
     (code & 0xFC00) == 0xDC00
 }
 
-#[sealed]
 impl<'text> TextSource<'text> for [u16] {
     type CharIter = Utf16CharIter<'text>;
     type CharIndexIter = Utf16CharIndexIter<'text>;

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -11,6 +11,7 @@ use super::TextSource;
 
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use core::char;
 use core::ops::Range;
 
 use crate::{

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -1,0 +1,195 @@
+// Copyright 2023 The Mozilla Foundation. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::__seal_text_source;
+use super::TextSource;
+
+use sealed::sealed;
+
+/// Implementation of TextSource for UTF-16 text in a [u16] array.
+/// Note that there could be unpaired surrogates present!
+
+// Convenience functions to check whether a UTF16 code unit is a surrogate.
+#[inline]
+fn is_high_surrogate(code: u16) -> bool {
+    (code & 0xFC00) == 0xD800
+}
+#[inline]
+fn is_low_surrogate(code: u16) -> bool {
+    (code & 0xFC00) == 0xDC00
+}
+
+#[sealed]
+impl<'text> TextSource<'text> for [u16] {
+    type CharIter = Utf16CharIter<'text>;
+    type CharIndexIter = Utf16CharIndexIter<'text>;
+    type IndexLenIter = Utf16IndexLenIter<'text>;
+
+    #[inline]
+    fn len(&self) -> usize {
+        (self as &[u16]).len()
+    }
+    fn char_at(&self, index: usize) -> Option<(char, usize)> {
+        if index >= self.len() {
+            return None;
+        }
+        // Get the indicated code unit and try simply converting it to a char;
+        // this will fail if it is half of a surrogate pair.
+        let c = self[index];
+        if let Some(ch) = char::from_u32(c.into()) {
+            return Some((ch, 1));
+        }
+        // If it's a low surrogate, and was immediately preceded by a high surrogate,
+        // then we're in the middle of a (valid) character, and should return None.
+        if is_low_surrogate(c) && index > 0 && is_high_surrogate(self[index - 1]) {
+            return None;
+        }
+        // Otherwise, try to decode, returning REPLACEMENT_CHARACTER for errors.
+        if let Some(ch) = char::decode_utf16(self[index..].iter().cloned()).next() {
+            if let Ok(ch) = ch {
+                // This must be a surrogate pair, otherwise char::from_u32() above should
+                // have succeeded!
+                debug_assert!(ch.len_utf16() == 2, "BMP should have already been handled");
+                return Some((ch, ch.len_utf16()));
+            }
+        } else {
+            debug_assert!(
+                false,
+                "Why did decode_utf16 return None when we're not at the end?"
+            );
+            return None;
+        }
+        // Failed to decode UTF-16: we must have encountered an unpaired surrogate.
+        // Return REPLACEMENT_CHARACTER (not None), to continue processing the following text
+        // and keep indexing correct.
+        Some((char::REPLACEMENT_CHARACTER, 1))
+    }
+    #[inline]
+    fn chars(&'text self) -> Self::CharIter {
+        Utf16CharIter::new(&self)
+    }
+    #[inline]
+    fn char_indices(&'text self) -> Self::CharIndexIter {
+        Utf16CharIndexIter::new(&self)
+    }
+    #[inline]
+    fn indices_lengths(&'text self) -> Self::IndexLenIter {
+        Utf16IndexLenIter::new(&self)
+    }
+    #[inline]
+    fn char_len(ch: char) -> usize {
+        ch.len_utf16()
+    }
+}
+
+/// Iterator over UTF-16 text in a [u16] slice, returning (index, char_len) tuple.
+#[derive(Debug)]
+pub struct Utf16IndexLenIter<'text> {
+    text: &'text [u16],
+    cur_pos: usize,
+}
+
+impl<'text> Utf16IndexLenIter<'text> {
+    #[inline]
+    pub fn new(text: &'text [u16]) -> Self {
+        Utf16IndexLenIter { text, cur_pos: 0 }
+    }
+}
+
+impl Iterator for Utf16IndexLenIter<'_> {
+    type Item = (usize, usize);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((_, char_len)) = self.text.char_at(self.cur_pos) {
+            let result = (self.cur_pos, char_len);
+            self.cur_pos += char_len;
+            return Some(result);
+        }
+        None
+    }
+}
+
+/// Iterator over UTF-16 text in a [u16] slice, returning (index, char) tuple.
+#[derive(Debug)]
+pub struct Utf16CharIndexIter<'text> {
+    text: &'text [u16],
+    cur_pos: usize,
+}
+
+impl<'text> Utf16CharIndexIter<'text> {
+    pub fn new(text: &'text [u16]) -> Self {
+        Utf16CharIndexIter { text, cur_pos: 0 }
+    }
+}
+
+impl Iterator for Utf16CharIndexIter<'_> {
+    type Item = (usize, char);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((ch, char_len)) = self.text.char_at(self.cur_pos) {
+            let result = (self.cur_pos, ch);
+            self.cur_pos += char_len;
+            return Some(result);
+        }
+        None
+    }
+}
+
+/// Iterator over UTF-16 text in a [u16] slice, returning Unicode chars.
+/// (Unlike the other iterators above, this also supports reverse iteration.)
+#[derive(Debug)]
+pub struct Utf16CharIter<'text> {
+    text: &'text [u16],
+    cur_pos: usize,
+    end_pos: usize,
+}
+
+impl<'text> Utf16CharIter<'text> {
+    pub fn new(text: &'text [u16]) -> Self {
+        Utf16CharIter {
+            text,
+            cur_pos: 0,
+            end_pos: text.len(),
+        }
+    }
+}
+
+impl Iterator for Utf16CharIter<'_> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((ch, char_len)) = self.text.char_at(self.cur_pos) {
+            self.cur_pos += char_len;
+            return Some(ch);
+        }
+        None
+    }
+}
+
+impl DoubleEndedIterator for Utf16CharIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.end_pos <= self.cur_pos {
+            return None;
+        }
+        self.end_pos -= 1;
+        if let Some(ch) = char::from_u32(self.text[self.end_pos] as u32) {
+            return Some(ch);
+        }
+        if self.end_pos > self.cur_pos {
+            if let Some((ch, char_len)) = self.text.char_at(self.end_pos - 1) {
+                if char_len == 2 {
+                    self.end_pos -= 1;
+                    return Some(ch);
+                }
+            }
+        }
+        Some(char::REPLACEMENT_CHARACTER)
+    }
+}

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -10,8 +10,105 @@
 use super::__seal_text_source;
 use super::TextSource;
 
+use alloc::vec::Vec;
 use core::ops::Range;
 use sealed::sealed;
+
+use crate::{BidiClass, BidiDataSource, HardcodedBidiData, Level, ParagraphInfo};
+use crate::compute_initial_info;
+
+/// Initial bidi information of the text (UTF-16 version).
+///
+/// Contains the text paragraphs and `BidiClass` of its characters.
+#[derive(PartialEq, Debug)]
+pub struct InitialInfo<'text> {
+    /// The text
+    pub text: &'text [u16],
+
+    /// The BidiClass of the character at each code unit in the text.
+    /// If a character is multiple code units, its class will appear multiple times in the vector.
+    pub original_classes: Vec<BidiClass>,
+
+    /// The boundaries and level of each paragraph within the text.
+    pub paragraphs: Vec<ParagraphInfo>,
+}
+
+impl<'text> InitialInfo<'text> {
+    /// Find the paragraphs and BidiClasses in a string of text.
+    ///
+    /// <http://www.unicode.org/reports/tr9/#The_Paragraph_Level>
+    ///
+    /// Also sets the class for each First Strong Isolate initiator (FSI) to LRI or RLI if a strong
+    /// character is found before the matching PDI.  If no strong character is found, the class will
+    /// remain FSI, and it's up to later stages to treat these as LRI when needed.
+    ///
+    /// The `hardcoded-data` Cargo feature (enabled by default) must be enabled to use this.
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
+    #[cfg(feature = "hardcoded-data")]
+    pub fn new(text: &[u16], default_para_level: Option<Level>) -> InitialInfo<'_> {
+        Self::new_with_data_source(&HardcodedBidiData, text, default_para_level)
+    }
+
+    /// Find the paragraphs and BidiClasses in a string of text, with a custom [`BidiDataSource`]
+    /// for Bidi data. If you just wish to use the hardcoded Bidi data, please use [`InitialInfo::new()`]
+    /// instead (enabled with tbe default `hardcoded-data` Cargo feature)
+    ///
+    /// <http://www.unicode.org/reports/tr9/#The_Paragraph_Level>
+    ///
+    /// Also sets the class for each First Strong Isolate initiator (FSI) to LRI or RLI if a strong
+    /// character is found before the matching PDI.  If no strong character is found, the class will
+    /// remain FSI, and it's up to later stages to treat these as LRI when needed.
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
+    pub fn new_with_data_source<'a, D: BidiDataSource>(
+        data_source: &D,
+        text: &'a [u16],
+        default_para_level: Option<Level>,
+    ) -> InitialInfo<'a> {
+        InitialInfoExt::new_with_data_source(data_source, text, default_para_level).base
+    }
+}
+
+/// Extended version of InitialInfo (not public API).
+#[derive(PartialEq, Debug)]
+struct InitialInfoExt<'text> {
+    /// The base InitialInfo for the text, recording its paragraphs and bidi classes.
+    base: InitialInfo<'text>,
+
+    /// Parallel to base.paragraphs, records whether each paragraph is "pure LTR" that
+    /// requires no further bidi processing (i.e. there are no RTL characters or bidi
+    /// control codes present).
+    pure_ltr: Vec<bool>,
+}
+
+impl<'text> InitialInfoExt<'text> {
+    /// Find the paragraphs and BidiClasses in a string of text, with a custom [`BidiDataSource`]
+    /// for Bidi data. If you just wish to use the hardcoded Bidi data, please use [`InitialInfo::new()`]
+    /// instead (enabled with tbe default `hardcoded-data` Cargo feature)
+    ///
+    /// <http://www.unicode.org/reports/tr9/#The_Paragraph_Level>
+    ///
+    /// Also sets the class for each First Strong Isolate initiator (FSI) to LRI or RLI if a strong
+    /// character is found before the matching PDI.  If no strong character is found, the class will
+    /// remain FSI, and it's up to later stages to treat these as LRI when needed.
+    #[cfg_attr(feature = "flame_it", flamer::flame)]
+    pub fn new_with_data_source<'a, D: BidiDataSource>(
+        data_source: &D,
+        text: &'a [u16],
+        default_para_level: Option<Level>,
+    ) -> InitialInfoExt<'a> {
+        let (original_classes, paragraphs, pure_ltr) =
+            compute_initial_info(data_source, text, default_para_level);
+
+        InitialInfoExt {
+            base: InitialInfo {
+                text,
+                original_classes,
+                paragraphs,
+            },
+            pure_ltr,
+        }
+    }
+}
 
 /// Implementation of TextSource for UTF-16 text in a [u16] array.
 /// Note that there could be unpaired surrogates present!

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeMap;
 use unicode_bidi::bidi_class;
-use unicode_bidi::{format_chars, level, BidiInfo, Level};
+use unicode_bidi::{format_chars, level, BidiInfo, BidiInfoU16, Level};
 
 #[derive(Debug)]
 #[allow(dead_code)] // lint ignores the Debug impl but that's what we use this for
@@ -110,6 +110,7 @@ fn test_basic_conformance() {
             assert!(bitset > 0);
 
             let input_string = get_sample_string_from_bidi_classes(&input_classes);
+            let input_string16: Vec<_> = input_string.encode_utf16().collect();
 
             for input_base_level in gen_base_levels_for_base_tests(bitset) {
                 let bidi_info = BidiInfo::new(&input_string, input_base_level);
@@ -126,7 +127,21 @@ fn test_basic_conformance() {
                 // However, as an internal invariant of this crate we would like to ensure these stay
                 // the same to reduce confusion. This is an assert instead of appending to the `fails`
                 // list since it is testing an internal invariant between two APIs.
-                assert_eq!(reorder_map, visual_runs_levels, "Maps returned by reorder_visual() and visual_runs() must be the same, for line {}", line);
+                assert_eq!(
+                    reorder_map, visual_runs_levels,
+                    "Maps returned by reorder_visual() and visual_runs() must be the same, for line {}",
+                    line
+                );
+
+                // Verify that the UTF-16 API returns the same levels.
+                let bidi_info16 = BidiInfoU16::new(&input_string16, input_base_level);
+                let para16 = &bidi_info16.paragraphs[0];
+                let levels16 = bidi_info16.reordered_levels_per_char(para16, para16.range.clone());
+                assert_eq!(
+                    levels, levels16,
+                    "UTF-8 and UTF-16 APIs must return the same per-char levels, for line {}",
+                    line
+                );
 
                 let actual_ordering: Vec<String> = reorder_map
                     .iter()

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -9,7 +9,8 @@
 
 use std::collections::BTreeMap;
 use unicode_bidi::bidi_class;
-use unicode_bidi::{format_chars, level, BidiInfo, BidiInfoU16, Level};
+use unicode_bidi::utf16::BidiInfo as BidiInfoU16;
+use unicode_bidi::{format_chars, level, BidiInfo, Level};
 
 #[derive(Debug)]
 #[allow(dead_code)] // lint ignores the Debug impl but that's what we use this for


### PR DESCRIPTION
This aims to provide "native" UTF-16 support, with `*U16` versions of `InitialInfo`, `BidiInfo`, and `Paragraph` structs that are parallel to the existing types but work on a `[u16]` text buffer instead of a `str`.

Fixes https://github.com/servo/unicode-bidi/issues/108