### PR TITLE
Skip over X9 characters when calculating end classes for isolating_run_sequences().

### DIFF
--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -59,7 +59,17 @@ pub fn isolating_run_sequences(
         assert!(!stack.is_empty());
 
         let start_class = original_classes[run.start];
-        let end_class = original_classes[run.end - 1];
+        // > In rule X10, [..] skip over any BNs when [..].
+        // > Do the same when determining if the last character of the sequence is an isolate initiator.
+        //
+        // <https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters>
+        let end_class = original_classes[run.start..run.end]
+            .iter()
+            .copied()
+            .rev()
+            .filter(not_removed_by_x9)
+            .next()
+            .unwrap_or(start_class);
 
         let mut sequence = if start_class == PDI && stack.len() > 1 {
             // Continue a previous sequence interrupted by an isolate.


### PR DESCRIPTION
Fixes #119

Spec's a bit confusing here since it talks about this in the https://www.unicode.org/reports/tr9/#Retaining_Explicit_Formatting_Characters entry for X10, but the algorithm being tweaked is actually BD13, which X10 invokes.

This will be fixed once I actually clean things up.