### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,47 +13,26 @@ jobs:
         rust: [1.36.0, stable, beta, nightly]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-          profile: minimal
       - name: Unpin dependencies except on MSRV
         if: matrix.rust != '1.36.0'
         run: cargo update
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features "serde"
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features=hardcoded-data
+      - run: cargo build --all-targets
+      - run: cargo test
+      - run: cargo test --features "serde"
+      - run: cargo test --no-default-features
+      - run: cargo test --no-default-features --features=hardcoded-data
   Fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+      - run: cargo fmt --check
 
   build_result:
     name: homu build finished


### PR DESCRIPTION
This PR updates outdated and replaces unmaintained actions in the GitHub Actions workflows.

The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/servo/unicode-bidi/actions/runs/7561082906:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions-rs/toolchain@v1, actions-rs/cargo@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The PR will get rid of those warnings.