### PR TITLE
[smallvec] Use SmallVec for some internal scratch vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ name = "unicode_bidi"
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.4", optional = true }
 serde = { version = ">=0.8, <2.0", default-features = false, optional = true, features = ["derive"] }
+smallvec = { version = ">=1.13", optional = true, features = ["union"] }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@
 extern crate std;
 #[macro_use]
 extern crate alloc;
+#[cfg(feature = "smallvec")]
+extern crate smallvec;
 
 pub mod data_source;
 pub mod deprecated;
@@ -99,6 +101,8 @@ use core::cmp;
 use core::iter::repeat;
 use core::ops::Range;
 use core::str::CharIndices;
+#[cfg(feature = "smallvec")]
+use smallvec::SmallVec;
 
 use crate::format_chars as chars;
 use crate::BidiClass::*;
@@ -300,6 +304,9 @@ fn compute_initial_info<'a, D: BidiDataSource, T: TextSource<'a> + ?Sized>(
     let mut original_classes = Vec::with_capacity(text.len());
 
     // The stack contains the starting code unit index for each nested isolate we're inside.
+    #[cfg(feature = "smallvec")]
+    let mut isolate_stack = SmallVec::<[usize; 8]>::new();
+    #[cfg(not(feature = "smallvec"))]
     let mut isolate_stack = Vec::new();
 
     debug_assert!(


### PR DESCRIPTION
We have some temporary vectors used during processing that will usually only hold a few entries. By using TinyVec here, we can avoid extra heap allocations in common cases.

(In Gecko's usage, I'm seeing around 4% improvement on the bidi- resolution subtest of perf_reftest_singletons with this change.)