### PR TITLE
More use of SmallVec

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -9,8 +9,6 @@
 
 //! This module holds deprecated assets only.
 
-use alloc::vec::Vec;
-
 use super::*;
 
 /// Find the level runs within a line and return them in visual order.

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -12,7 +12,7 @@
 //! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
 #[cfg(feature = "smallvec")]
-use smallvec::{SmallVec, smallvec};
+use smallvec::{smallvec, SmallVec};
 
 use super::char_data::{
     is_rtl,
@@ -37,7 +37,7 @@ pub fn compute<'a, T: TextSource<'a> + ?Sized>(
 
     // <http://www.unicode.org/reports/tr9/#X1>
     #[cfg(feature = "smallvec")]
-    let mut stack: SmallVec::<[Status; 8]> = smallvec![Status {
+    let mut stack: SmallVec<[Status; 8]> = smallvec![Status {
         level: para_level,
         status: OverrideStatus::Neutral,
     }];

--- a/src/explicit.rs
+++ b/src/explicit.rs
@@ -11,6 +11,9 @@
 //!
 //! <http://www.unicode.org/reports/tr9/#Explicit_Levels_and_Directions>
 
+#[cfg(feature = "smallvec")]
+use smallvec::{SmallVec, smallvec};
+
 use super::char_data::{
     is_rtl,
     BidiClass::{self, *},
@@ -33,6 +36,12 @@ pub fn compute<'a, T: TextSource<'a> + ?Sized>(
     assert_eq!(text.len(), original_classes.len());
 
     // <http://www.unicode.org/reports/tr9/#X1>
+    #[cfg(feature = "smallvec")]
+    let mut stack: SmallVec::<[Status; 8]> = smallvec![Status {
+        level: para_level,
+        status: OverrideStatus::Neutral,
+    }];
+    #[cfg(not(feature = "smallvec"))]
     let mut stack = vec![Status {
         level: para_level,
         status: OverrideStatus::Neutral,

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -9,6 +9,7 @@
 
 //! 3.3.4 - 3.3.6. Resolve implicit levels and types.
 
+#[cfg(not(feature = "smallvec"))]
 use alloc::vec::Vec;
 use core::cmp::max;
 #[cfg(feature = "smallvec")]
@@ -250,6 +251,11 @@ pub fn resolve_weak<'a, T: TextSource<'a> + ?Sized>(
     }
 }
 
+#[cfg(feature = "smallvec")]
+type BracketPairVec = SmallVec::<[BracketPair; 8]>;
+#[cfg(not(feature = "smallvec"))]
+type BracketPairVec = Vec::<BracketPair>;
+
 /// 3.3.5 Resolving Neutral Types
 ///
 /// <http://www.unicode.org/reports/tr9/#Resolving_Neutral_Types>
@@ -273,7 +279,8 @@ pub fn resolve_neutral<'a, D: BidiDataSource, T: TextSource<'a> + ?Sized>(
 
     // > Identify the bracket pairs in the current isolating run sequence according to BD16.
     // We use processing_classes, not original_classes, due to BD14/BD15
-    let bracket_pairs = identify_bracket_pairs(text, data_source, sequence, processing_classes);
+    let mut bracket_pairs = BracketPairVec::new();
+    identify_bracket_pairs(text, data_source, sequence, processing_classes, &mut bracket_pairs);
 
     // > For each bracket-pair element in the list of pairs of text positions
     //
@@ -493,8 +500,8 @@ fn identify_bracket_pairs<'a, T: TextSource<'a> + ?Sized, D: BidiDataSource>(
     data_source: &D,
     run_sequence: &IsolatingRunSequence,
     original_classes: &[BidiClass],
-) -> Vec<BracketPair> {
-    let mut ret = vec![];
+    bracket_pairs: &mut BracketPairVec,
+) {
     #[cfg(feature = "smallvec")]
     let mut stack = SmallVec::<[(char, usize, usize); 8]>::new();
     #[cfg(not(feature = "smallvec"))]
@@ -544,7 +551,7 @@ fn identify_bracket_pairs<'a, T: TextSource<'a> + ?Sized, D: BidiDataSource>(
                                 start_run: element.2,
                                 end_run: run_index,
                             };
-                            ret.push(pair);
+                            bracket_pairs.push(pair);
 
                             // > Pop the stack through the current stack element inclusively.
                             stack.truncate(stack_index);
@@ -557,8 +564,7 @@ fn identify_bracket_pairs<'a, T: TextSource<'a> + ?Sized, D: BidiDataSource>(
     }
     // > Sort the list of pairs of text positions in ascending order based on
     // > the text position of the opening paired bracket.
-    ret.sort_by_key(|r| r.start);
-    ret
+    bracket_pairs.sort_by_key(|r| r.start);
 }
 
 /// 3.3.6 Resolving Implicit Levels

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -567,11 +567,11 @@ fn identify_bracket_pairs<'a, T: TextSource<'a> + ?Sized, D: BidiDataSource>(
 ///
 /// <http://www.unicode.org/reports/tr9/#Resolving_Implicit_Levels>
 #[cfg_attr(feature = "flame_it", flamer::flame)]
-pub fn resolve_levels(original_classes: &[BidiClass], levels: &mut [Level]) -> Level {
+pub fn resolve_levels(processing_classes: &[BidiClass], levels: &mut [Level]) -> Level {
     let mut max_level = Level::ltr();
-    assert_eq!(original_classes.len(), levels.len());
+    assert_eq!(processing_classes.len(), levels.len());
     for i in 0..levels.len() {
-        match (levels[i].is_rtl(), original_classes[i]) {
+        match (levels[i].is_rtl(), processing_classes[i]) {
             (false, AN) | (false, EN) => levels[i].raise(2).expect("Level number error"),
             (false, R) | (true, L) | (true, EN) | (true, AN) => {
                 levels[i].raise(1).expect("Level number error")

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -252,9 +252,9 @@ pub fn resolve_weak<'a, T: TextSource<'a> + ?Sized>(
 }
 
 #[cfg(feature = "smallvec")]
-type BracketPairVec = SmallVec::<[BracketPair; 8]>;
+type BracketPairVec = SmallVec<[BracketPair; 8]>;
 #[cfg(not(feature = "smallvec"))]
-type BracketPairVec = Vec::<BracketPair>;
+type BracketPairVec = Vec<BracketPair>;
 
 /// 3.3.5 Resolving Neutral Types
 ///
@@ -280,7 +280,13 @@ pub fn resolve_neutral<'a, D: BidiDataSource, T: TextSource<'a> + ?Sized>(
     // > Identify the bracket pairs in the current isolating run sequence according to BD16.
     // We use processing_classes, not original_classes, due to BD14/BD15
     let mut bracket_pairs = BracketPairVec::new();
-    identify_bracket_pairs(text, data_source, sequence, processing_classes, &mut bracket_pairs);
+    identify_bracket_pairs(
+        text,
+        data_source,
+        sequence,
+        processing_classes,
+        &mut bracket_pairs,
+    );
 
     // > For each bracket-pair element in the list of pairs of text positions
     //

--- a/src/level.rs
+++ b/src/level.rs
@@ -17,10 +17,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::{
-    convert::{From, Into},
-    slice,
-};
+use core::slice;
 
 use super::char_data::BidiClass;
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -14,6 +14,8 @@
 use alloc::vec::Vec;
 use core::cmp::max;
 use core::ops::Range;
+#[cfg(feature = "smallvec")]
+use smallvec::{SmallVec, smallvec};
 
 use super::level::Level;
 use super::BidiClass::{self, *};
@@ -52,6 +54,9 @@ pub fn isolating_run_sequences(
 
     // When we encounter an isolate initiator, we push the current sequence onto the
     // stack so we can resume it after the matching PDI.
+    #[cfg(feature = "smallvec")]
+    let mut stack: SmallVec::<[Vec<Range<usize>>; 8]> = smallvec![vec![]];
+    #[cfg(not(feature = "smallvec"))]
     let mut stack = vec![vec![]];
 
     for run in runs {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use core::cmp::max;
 use core::ops::Range;
 #[cfg(feature = "smallvec")]
-use smallvec::{SmallVec, smallvec};
+use smallvec::{smallvec, SmallVec};
 
 use super::level::Level;
 use super::BidiClass::{self, *};
@@ -55,7 +55,7 @@ pub fn isolating_run_sequences(
     // When we encounter an isolate initiator, we push the current sequence onto the
     // stack so we can resume it after the matching PDI.
     #[cfg(feature = "smallvec")]
-    let mut stack: SmallVec::<[Vec<Range<usize>>; 8]> = smallvec![vec![]];
+    let mut stack: SmallVec<[Vec<Range<usize>>; 8]> = smallvec![vec![]];
     #[cfg(not(feature = "smallvec"))]
     let mut stack = vec![vec![]];
 


### PR DESCRIPTION
This enables use of SmallVec for some more temporary vectors, to reduce heap allocations in common cases.

Also a couple of cosmetic clean-ups noticed in passing (which have no functional impact).