### PR TITLE
Two tiny fixes I noticed while porting the crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "flame",
  "flamer",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1154,12 +1154,12 @@ fn reorder_levels<'a, T: TextSource<'a> + ?Sized>(
     let mut reset_from: Option<usize> = Some(0);
     let mut reset_to: Option<usize> = None;
     let mut prev_level = para_level;
-    for ((i, c), (_, length)) in line_text.char_indices().zip(line_text.indices_lengths()) {
+    for (i, length) in line_text.indices_lengths() {
         match line_classes[i] {
             // Segment separator, Paragraph separator
             B | S => {
                 assert_eq!(reset_to, None);
-                reset_to = Some(i + T::char_len(c));
+                reset_to = Some(i + length);
                 if reset_from.is_none() {
                     reset_from = Some(i);
                 }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -269,7 +269,7 @@ impl IsolatingRunSequence {
 
         (current.start..pos)
             .rev()
-            .chain(prev_runs.iter().rev().flat_map(Clone::clone))
+            .chain(prev_runs.iter().cloned().rev().flat_map(|r| r.rev()))
     }
 }
 


### PR DESCRIPTION
Hello.

I have been [porting the crate to Zig](https://git.sr.ht/~asibahi/zabadi), and while I was doing I noticed two tiny issues.

First I wrote up on https://github.com/servo/unicode-bidi/issues/141 . I am still not entirely sure how one would test for that.

Second is a redundant declared variant in `reorder_levels`.