### PR TITLE
Guard L2 reordering against the maximum implicit level (126)

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -55,6 +55,13 @@ pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
     // Re-order the odd runs.
     // <http://www.unicode.org/reports/tr9/#L2>
 
+    // A uniform, even (LTR) level needs no reordering; mirroring the guard in
+    // `reorder_visual` also avoids overflowing `new_lowest_ge_rtl` when the line
+    // sits at the maximum implicit level 126 (#145).
+    if min_level == max_level && min_level.is_ltr() {
+        return runs;
+    }
+
     // Stop at the lowest *odd* level.
     min_level = min_level.new_lowest_ge_rtl().expect("Level error");
 
@@ -86,4 +93,18 @@ pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
     }
 
     runs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // Regression test for issue #145: a uniform line at the maximum implicit
+    // level (126) must not overflow the L2 reordering step.
+    fn test_visual_runs_max_implicit_level() {
+        #[allow(deprecated)]
+        let runs = visual_runs(0..1, &[Level::new(126).unwrap()]);
+        assert_eq!(runs, vec![0..1]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -952,6 +952,13 @@ fn visual_runs_for_line(levels: Vec<Level>, line: &Range<usize>) -> (Vec<Level>,
     // Re-order the odd runs.
     // <http://www.unicode.org/reports/tr9/#L2>
 
+    // A uniform, even (LTR) level needs no reordering; mirroring the guard in
+    // `reorder_visual` also avoids overflowing `new_lowest_ge_rtl` when the line
+    // sits at the maximum implicit level 126 (#145).
+    if min_level == max_level && min_level.is_ltr() {
+        return (levels, runs);
+    }
+
     // Stop at the lowest *odd* level.
     min_level = min_level.new_lowest_ge_rtl().expect("Level error");
     // This loop goes through contiguous chunks of level runs that have a level
@@ -2056,6 +2063,34 @@ mod tests {
         for run in runs {
             let _ = &s[run]; // should be valid slice of s
         }
+    }
+
+    #[test]
+    #[cfg(feature = "hardcoded-data")]
+    // Regression test for issue #145: a line at the maximum implicit level (126)
+    // must not overflow the L2 reordering step.
+    fn test_visual_runs_max_implicit_level() {
+        // Nesting isolates drives the explicit level to its 125 ceiling; the
+        // trailing digit is then raised to implicit level 126 by rule I2.
+        let mut text = String::new();
+        for i in 0..140 {
+            text.push(if i % 2 == 0 { '\u{2067}' } else { '\u{2066}' });
+        }
+        let digit = text.len();
+        text.push('9');
+
+        let bidi = BidiInfo::new(&text, Some(Level::ltr()));
+        assert_eq!(bidi.levels[digit].number(), 126);
+        let (_, runs) = bidi.visual_runs(&bidi.paragraphs[0], digit..digit + 1);
+        assert_eq!(runs, vec![digit..digit + 1]);
+
+        // utf-16 routes through the same helper.
+        let text16 = to_utf16(&text);
+        let bidi16 = BidiInfoU16::new(&text16, Some(Level::ltr()));
+        let digit16 = text16.len() - 1;
+        assert_eq!(bidi16.levels[digit16].number(), 126);
+        let (_, runs16) = bidi16.visual_runs(&bidi16.paragraphs[0], digit16..digit16 + 1);
+        assert_eq!(runs16, vec![digit16..digit16 + 1]);
     }
 
     #[test]


### PR DESCRIPTION
`BidiInfo::visual_runs` panics with `Level error: OutOfRangeNumber` when a line
sits entirely at the maximum implicit level 126. In the L2 step,
`min_level.new_lowest_ge_rtl()` evaluates `Level::new(126 | 1)` = `Level::new(127)`,
which is past the ceiling, so the following `.expect(...)` panics.

Level 126 is reachable by ordinary text: nest isolates/embeddings to the explicit
depth 125, then a digit inside is raised to implicit level 126 by rule I2 (as noted
in the issue, implicit resolution tops out at 126). Such a line is uniformly 126,
all even, so nothing needs reordering.

`reorder_visual` already guards this with `if min == max && min.is_ltr()`. The
other two L2 implementations were missing it. This adds the same guard to
`visual_runs_for_line` (which backs `visual_runs` for both utf-8 and utf-16) and
to the deprecated `visual_runs`. For a uniform even level the guard matches what
the existing loop already produces, so behaviour is otherwise unchanged and the
conformance suite still passes.

Repro:

```rust
let mut s = String::new();
for i in 0..140 { s.push(if i % 2 == 0 { '\u{2067}' } else { '\u{2066}' }); }
let d = s.len(); s.push('9');
let bidi = BidiInfo::new(&s, Some(Level::ltr())); // level at d == 126
bidi.visual_runs(&bidi.paragraphs[0], d..d + 1);  // panics before this change
```

Fixes #145.
