### PR TITLE
Remove unnecessary casts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1357,7 +1357,7 @@ impl<'text> TextSource<'text> for str {
 
     #[inline]
     fn len(&self) -> usize {
-        (self as &str).len()
+        self.len()
     }
     #[inline]
     fn char_at(&self, index: usize) -> Option<(char, usize)> {
@@ -1370,15 +1370,15 @@ impl<'text> TextSource<'text> for str {
     }
     #[inline]
     fn subrange(&self, range: Range<usize>) -> &Self {
-        &(self as &str)[range]
+        &self[range]
     }
     #[inline]
     fn chars(&'text self) -> Self::CharIter {
-        (self as &str).chars()
+        self.chars()
     }
     #[inline]
     fn char_indices(&'text self) -> Self::CharIndexIter {
-        (self as &str).char_indices()
+        self.char_indices()
     }
     #[inline]
     fn indices_lengths(&'text self) -> Self::IndexLenIter {

--- a/src/utf16.rs
+++ b/src/utf16.rs
@@ -629,7 +629,7 @@ impl<'text> TextSource<'text> for [u16] {
 
     #[inline]
     fn len(&self) -> usize {
-        (self as &[u16]).len()
+        self.len()
     }
     fn char_at(&self, index: usize) -> Option<(char, usize)> {
         if index >= self.len() {
@@ -668,7 +668,7 @@ impl<'text> TextSource<'text> for [u16] {
     }
     #[inline]
     fn subrange(&self, range: Range<usize>) -> &Self {
-        &(self as &[u16])[range]
+        &self[range]
     }
     #[inline]
     fn chars(&'text self) -> Self::CharIter {


### PR DESCRIPTION
I believe these casts can be safely removed, as the source type is already the target type.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes
